### PR TITLE
Add support for auto modprobe 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "termcolor",
  "thiserror",
  "toml",
 ]
@@ -335,6 +336,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"
 thiserror = "1.0"
+termcolor = "1.4"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/src/commands/ext.rs
+++ b/src/commands/ext.rs
@@ -22,11 +22,12 @@ struct Extension {
 /// Print a colored success message
 fn print_colored_success(message: &str) {
     // Use auto-detection but fallback gracefully
-    let color_choice = if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
-        ColorChoice::Never
-    } else {
-        ColorChoice::Auto
-    };
+    let color_choice =
+        if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
+            ColorChoice::Never
+        } else {
+            ColorChoice::Auto
+        };
 
     let mut stdout = StandardStream::stdout(color_choice);
     let mut color_spec = ColorSpec::new();
@@ -35,21 +36,22 @@ fn print_colored_success(message: &str) {
     if stdout.set_color(&color_spec).is_ok() && color_choice != ColorChoice::Never {
         let _ = write!(&mut stdout, "[SUCCESS]");
         let _ = stdout.reset();
-        println!(" {}", message);
+        println!(" {message}");
     } else {
         // Fallback for environments without color support
-        println!("[SUCCESS] {}", message);
+        println!("[SUCCESS] {message}");
     }
 }
 
 /// Print a colored info message
 fn print_colored_info(message: &str) {
     // Use auto-detection but fallback gracefully
-    let color_choice = if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
-        ColorChoice::Never
-    } else {
-        ColorChoice::Auto
-    };
+    let color_choice =
+        if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
+            ColorChoice::Never
+        } else {
+            ColorChoice::Auto
+        };
 
     let mut stdout = StandardStream::stdout(color_choice);
     let mut color_spec = ColorSpec::new();
@@ -58,10 +60,10 @@ fn print_colored_info(message: &str) {
     if stdout.set_color(&color_spec).is_ok() && color_choice != ColorChoice::Never {
         let _ = write!(&mut stdout, "[INFO]");
         let _ = stdout.reset();
-        println!(" {}", message);
+        println!(" {message}");
     } else {
         // Fallback for environments without color support
-        println!("[INFO] {}", message);
+        println!("[INFO] {message}");
     }
 }
 
@@ -1521,17 +1523,17 @@ fn run_modprobe(modules: &[String]) -> Result<(), SystemdError> {
             .stderr(Stdio::piped())
             .output()
             .map_err(|e| SystemdError::CommandFailed {
-                command: format!("{} {}", command_name, module),
+                command: format!("{command_name} {module}"),
                 source: e,
             })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            eprintln!("Warning: Failed to load module {}: {}", module, stderr);
+            eprintln!("Warning: Failed to load module {module}: {stderr}");
             // Don't fail the entire operation for individual module failures
             // Just log the warning and continue with other modules
         } else {
-            print_colored_success(&format!("Module {} loaded successfully.", module));
+            print_colored_success(&format!("Module {module} loaded successfully."));
         }
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -3,6 +3,9 @@
 //! This module provides a consistent interface for all output in the CLI,
 //! handling verbosity levels and formatting consistently across all commands.
 
+use std::io::Write;
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
 /// Output manager that handles verbosity and formatting consistently
 pub struct OutputManager {
     verbose: bool,
@@ -14,21 +17,82 @@ impl OutputManager {
         Self { verbose }
     }
 
+    /// Print a colored prefix with message
+    fn print_colored_prefix(&self, prefix: &str, color: Color, message: &str) {
+        let color_choice = if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
+            ColorChoice::Never
+        } else {
+            ColorChoice::Auto
+        };
+
+        let mut stdout = StandardStream::stdout(color_choice);
+        let mut color_spec = ColorSpec::new();
+        color_spec.set_fg(Some(color)).set_bold(true);
+
+        if stdout.set_color(&color_spec).is_ok() && color_choice != ColorChoice::Never {
+            let _ = write!(&mut stdout, "[{}]", prefix);
+            let _ = stdout.reset();
+            println!(" {}", message);
+        } else {
+            // Fallback for environments without color support
+            println!("[{}] {}", prefix, message);
+        }
+    }
+
+    /// Print a colored prefix with operation and message
+    fn print_colored_prefix_with_op(&self, prefix: &str, color: Color, operation: &str, message: &str) {
+        let color_choice = if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
+            ColorChoice::Never
+        } else {
+            ColorChoice::Auto
+        };
+
+        let mut stdout = StandardStream::stdout(color_choice);
+        let mut color_spec = ColorSpec::new();
+        color_spec.set_fg(Some(color)).set_bold(true);
+
+        if stdout.set_color(&color_spec).is_ok() && color_choice != ColorChoice::Never {
+            let _ = write!(&mut stdout, "[{}]", prefix);
+            let _ = stdout.reset();
+            println!(" {}: {}", operation, message);
+        } else {
+            // Fallback for environments without color support
+            println!("[{}] {}: {}", prefix, operation, message);
+        }
+    }
+
     /// Print a success message
     /// In non-verbose mode: shows brief success
     /// In verbose mode: shows detailed success with context
     pub fn success(&self, operation: &str, message: &str) {
         if self.verbose {
-            println!("✅ {operation}: {message}");
+            self.print_colored_prefix_with_op("SUCCESS", Color::Green, operation, message);
         } else {
-            println!("✅ {message}");
+            self.print_colored_prefix("SUCCESS", Color::Green, message);
         }
     }
 
     /// Print an error message
     /// Always shows detailed error information for developers
     pub fn error(&self, operation: &str, message: &str) {
-        eprintln!("❌ {operation}: {message}");
+        let color_choice = if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
+            ColorChoice::Never
+        } else {
+            ColorChoice::Auto
+        };
+
+        let mut stderr = StandardStream::stderr(color_choice);
+        let mut color_spec = ColorSpec::new();
+        color_spec.set_fg(Some(Color::Red)).set_bold(true);
+
+        if stderr.set_color(&color_spec).is_ok() && color_choice != ColorChoice::Never {
+            let _ = write!(&mut stderr, "[ERROR]");
+            let _ = stderr.reset();
+            eprintln!(" {}: {}", operation, message);
+        } else {
+            eprintln!("[ERROR] {}: {}", operation, message);
+        }
+
         if !self.verbose {
             eprintln!("   Use --verbose for more details");
         }
@@ -39,7 +103,7 @@ impl OutputManager {
     /// In verbose mode: shows all info
     pub fn info(&self, operation: &str, message: &str) {
         if self.verbose {
-            println!("ℹ️  {operation}: {message}");
+            self.print_colored_prefix_with_op("INFO", Color::Blue, operation, message);
         }
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -19,45 +19,53 @@ impl OutputManager {
 
     /// Print a colored prefix with message
     fn print_colored_prefix(&self, prefix: &str, color: Color, message: &str) {
-        let color_choice = if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
-            ColorChoice::Never
-        } else {
-            ColorChoice::Auto
-        };
+        let color_choice =
+            if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
+                ColorChoice::Never
+            } else {
+                ColorChoice::Auto
+            };
 
         let mut stdout = StandardStream::stdout(color_choice);
         let mut color_spec = ColorSpec::new();
         color_spec.set_fg(Some(color)).set_bold(true);
 
         if stdout.set_color(&color_spec).is_ok() && color_choice != ColorChoice::Never {
-            let _ = write!(&mut stdout, "[{}]", prefix);
+            let _ = write!(&mut stdout, "[{prefix}]");
             let _ = stdout.reset();
-            println!(" {}", message);
+            println!(" {message}");
         } else {
             // Fallback for environments without color support
-            println!("[{}] {}", prefix, message);
+            println!("[{prefix}] {message}");
         }
     }
 
     /// Print a colored prefix with operation and message
-    fn print_colored_prefix_with_op(&self, prefix: &str, color: Color, operation: &str, message: &str) {
-        let color_choice = if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
-            ColorChoice::Never
-        } else {
-            ColorChoice::Auto
-        };
+    fn print_colored_prefix_with_op(
+        &self,
+        prefix: &str,
+        color: Color,
+        operation: &str,
+        message: &str,
+    ) {
+        let color_choice =
+            if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
+                ColorChoice::Never
+            } else {
+                ColorChoice::Auto
+            };
 
         let mut stdout = StandardStream::stdout(color_choice);
         let mut color_spec = ColorSpec::new();
         color_spec.set_fg(Some(color)).set_bold(true);
 
         if stdout.set_color(&color_spec).is_ok() && color_choice != ColorChoice::Never {
-            let _ = write!(&mut stdout, "[{}]", prefix);
+            let _ = write!(&mut stdout, "[{prefix}]");
             let _ = stdout.reset();
-            println!(" {}: {}", operation, message);
+            println!(" {operation}: {message}");
         } else {
             // Fallback for environments without color support
-            println!("[{}] {}: {}", prefix, operation, message);
+            println!("[{prefix}] {operation}: {message}");
         }
     }
 
@@ -75,11 +83,12 @@ impl OutputManager {
     /// Print an error message
     /// Always shows detailed error information for developers
     pub fn error(&self, operation: &str, message: &str) {
-        let color_choice = if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
-            ColorChoice::Never
-        } else {
-            ColorChoice::Auto
-        };
+        let color_choice =
+            if std::env::var("NO_COLOR").is_ok() || std::env::var("AVOCADO_TEST_MODE").is_ok() {
+                ColorChoice::Never
+            } else {
+                ColorChoice::Auto
+            };
 
         let mut stderr = StandardStream::stderr(color_choice);
         let mut color_spec = ColorSpec::new();
@@ -88,9 +97,9 @@ impl OutputManager {
         if stderr.set_color(&color_spec).is_ok() && color_choice != ColorChoice::Never {
             let _ = write!(&mut stderr, "[ERROR]");
             let _ = stderr.reset();
-            eprintln!(" {}: {}", operation, message);
+            eprintln!(" {operation}: {message}");
         } else {
-            eprintln!("[ERROR] {}: {}", operation, message);
+            eprintln!("[ERROR] {operation}: {message}");
         }
 
         if !self.verbose {

--- a/tests/ext_integration_tests.rs
+++ b/tests/ext_integration_tests.rs
@@ -647,6 +647,134 @@ fn test_ext_merge_with_depmod_processing() {
     );
 }
 
+/// Test multiple extensions with both depmod and modprobe - verify single depmod call
+#[test]
+fn test_ext_merge_multiple_extensions_single_depmod() {
+    // This test specifically verifies your concern: two extensions with depmod + modprobe
+    // should result in ONE depmod call and ALL modules loaded
+    let current_dir = std::env::current_dir().expect("Failed to get current directory");
+    let fixtures_path = current_dir.join("tests/fixtures");
+    let release_dir = fixtures_path.join("extension-release.d");
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", fixtures_path.to_string_lossy(), original_path);
+
+    let output = run_avocadoctl_with_env(
+        &["ext", "merge", "--verbose"],
+        &[
+            ("AVOCADO_TEST_MODE", "1"),
+            ("PATH", &new_path),
+            (
+                "AVOCADO_EXTENSION_RELEASE_DIR",
+                &release_dir.to_string_lossy(),
+            ),
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "ext merge should succeed with multiple extensions"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    
+    // Verify depmod is called exactly once
+    let depmod_count = stdout.matches("Running depmod").count();
+    assert_eq!(
+        depmod_count, 1,
+        "Should call depmod exactly once even with multiple extensions requiring it"
+    );
+    
+    // Verify all modules from all extensions are loaded
+    assert!(
+        stdout.contains("Loading kernel modules:"),
+        "Should show module loading message"
+    );
+    
+    // Check that modules from multiple extensions are included
+    // From network-driver: e1000e igb ixgbe
+    // From storage-driver: ahci nvme  
+    // From gpu-driver: nvidia i915 radeon
+    // From sound-driver: snd_hda_intel
+    let has_network_modules = stdout.contains("e1000e") || stdout.contains("igb") || stdout.contains("ixgbe");
+    let has_storage_modules = stdout.contains("ahci") || stdout.contains("nvme");
+    let has_gpu_modules = stdout.contains("nvidia") || stdout.contains("i915") || stdout.contains("radeon");
+    let has_sound_modules = stdout.contains("snd_hda_intel");
+    
+    assert!(
+        has_network_modules || has_storage_modules || has_gpu_modules || has_sound_modules,
+        "Should load modules from multiple extensions. Stdout: {}", stdout
+    );
+    
+    assert!(
+        stdout.contains("Module loading completed"),
+        "Should show module loading completion"
+    );
+}
+
+/// Test ext merge with modprobe post-processing
+#[test]
+fn test_ext_merge_with_modprobe_processing() {
+    // Setup mock environment with release files that require both depmod and modprobe
+    let current_dir = std::env::current_dir().expect("Failed to get current directory");
+    let fixtures_path = current_dir.join("tests/fixtures");
+    let release_dir = fixtures_path.join("extension-release.d");
+
+    // Add fixtures path to PATH so mock binaries can be found
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", fixtures_path.to_string_lossy(), original_path);
+
+    // Set environment variables to use test release directory and mocks
+    let output = run_avocadoctl_with_env(
+        &["ext", "merge", "--verbose"],
+        &[
+            ("AVOCADO_TEST_MODE", "1"),
+            ("PATH", &new_path),
+            (
+                "AVOCADO_EXTENSION_RELEASE_DIR",
+                &release_dir.to_string_lossy(),
+            ),
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "ext merge should succeed with modprobe processing"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Starting extension merge process"),
+        "Should show merging message"
+    );
+    assert!(
+        stdout.contains("Extensions merged successfully"),
+        "Should show merge success"
+    );
+    assert!(
+        stdout.contains("Running depmod"),
+        "Should show depmod running message"
+    );
+    assert!(
+        stdout.contains("depmod completed successfully"),
+        "Should show depmod completion"
+    );
+    assert!(
+        stdout.contains("Loading kernel modules:"),
+        "Should show module loading message"
+    );
+    assert!(
+        stdout.contains("Module loading completed"),
+        "Should show module loading completion"
+    );
+
+    // Check that specific modules are being loaded (from our test fixtures)
+    assert!(
+        stdout.contains("nvidia") || stdout.contains("snd_hda_intel"),
+        "Should load modules from test extension files"
+    );
+}
+
 /// Test post-merge processing with no depmod needed
 #[test]
 fn test_ext_merge_no_depmod_needed() {

--- a/tests/ext_integration_tests.rs
+++ b/tests/ext_integration_tests.rs
@@ -365,11 +365,11 @@ fn test_ext_unmerge_with_mocks() {
         "Should show confext operation"
     );
     assert!(
-        stdout.contains("Running depmod"),
+        stdout.contains("[INFO] Running depmod"),
         "Should show depmod running message"
     );
     assert!(
-        stdout.contains("depmod completed successfully"),
+        stdout.contains("[SUCCESS] depmod completed successfully"),
         "Should show depmod completion"
     );
 }
@@ -536,17 +536,17 @@ fn test_ext_refresh_with_mocks() {
     );
 
     // Verify depmod is only called once at the end (during merge phase)
-    let depmod_count = stdout.matches("Running depmod").count();
+    let depmod_count = stdout.matches("[INFO] Running depmod").count();
     assert_eq!(
         depmod_count, 1,
         "Should call depmod exactly once during refresh (only during merge phase)"
     );
     assert!(
-        stdout.contains("Running depmod"),
+        stdout.contains("[INFO] Running depmod"),
         "Should show depmod running message"
     );
     assert!(
-        stdout.contains("depmod completed successfully"),
+        stdout.contains("[SUCCESS] depmod completed successfully"),
         "Should show depmod completion"
     );
 }
@@ -638,11 +638,11 @@ fn test_ext_merge_with_depmod_processing() {
         "Should show merge success"
     );
     assert!(
-        stdout.contains("Running depmod"),
+        stdout.contains("[INFO] Running depmod"),
         "Should show depmod running message"
     );
     assert!(
-        stdout.contains("depmod completed successfully"),
+        stdout.contains("[SUCCESS] depmod completed successfully"),
         "Should show depmod completion"
     );
 }
@@ -677,37 +677,37 @@ fn test_ext_merge_multiple_extensions_single_depmod() {
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    
+
     // Verify depmod is called exactly once
-    let depmod_count = stdout.matches("Running depmod").count();
+    let depmod_count = stdout.matches("[INFO] Running depmod").count();
     assert_eq!(
         depmod_count, 1,
         "Should call depmod exactly once even with multiple extensions requiring it"
     );
-    
+
     // Verify all modules from all extensions are loaded
     assert!(
-        stdout.contains("Loading kernel modules:"),
+        stdout.contains("[INFO] Loading kernel modules:"),
         "Should show module loading message"
     );
-    
+
     // Check that modules from multiple extensions are included
     // From network-driver: e1000e igb ixgbe
-    // From storage-driver: ahci nvme  
+    // From storage-driver: ahci nvme
     // From gpu-driver: nvidia i915 radeon
     // From sound-driver: snd_hda_intel
     let has_network_modules = stdout.contains("e1000e") || stdout.contains("igb") || stdout.contains("ixgbe");
     let has_storage_modules = stdout.contains("ahci") || stdout.contains("nvme");
     let has_gpu_modules = stdout.contains("nvidia") || stdout.contains("i915") || stdout.contains("radeon");
     let has_sound_modules = stdout.contains("snd_hda_intel");
-    
+
     assert!(
         has_network_modules || has_storage_modules || has_gpu_modules || has_sound_modules,
         "Should load modules from multiple extensions. Stdout: {}", stdout
     );
-    
+
     assert!(
-        stdout.contains("Module loading completed"),
+        stdout.contains("[SUCCESS] Module loading completed"),
         "Should show module loading completion"
     );
 }
@@ -752,19 +752,19 @@ fn test_ext_merge_with_modprobe_processing() {
         "Should show merge success"
     );
     assert!(
-        stdout.contains("Running depmod"),
+        stdout.contains("[INFO] Running depmod"),
         "Should show depmod running message"
     );
     assert!(
-        stdout.contains("depmod completed successfully"),
+        stdout.contains("[SUCCESS] depmod completed successfully"),
         "Should show depmod completion"
     );
     assert!(
-        stdout.contains("Loading kernel modules:"),
+        stdout.contains("[INFO] Loading kernel modules:"),
         "Should show module loading message"
     );
     assert!(
-        stdout.contains("Module loading completed"),
+        stdout.contains("[SUCCESS] Module loading completed"),
         "Should show module loading completion"
     );
 
@@ -782,12 +782,19 @@ fn test_ext_merge_no_depmod_needed() {
     let current_dir = std::env::current_dir().expect("Failed to get current directory");
     let fixtures_path = current_dir.join("tests/fixtures");
 
+    // Use a non-existent release directory to ensure no post-merge tasks run
+    let empty_release_dir = "/tmp/nonexistent_release_dir";
+
     let original_path = std::env::var("PATH").unwrap_or_default();
     let new_path = format!("{}:{}", fixtures_path.to_string_lossy(), original_path);
 
     let output = run_avocadoctl_with_env(
         &["ext", "merge", "--verbose"],
-        &[("AVOCADO_TEST_MODE", "1"), ("PATH", &new_path)],
+        &[
+            ("AVOCADO_TEST_MODE", "1"),
+            ("PATH", &new_path),
+            ("AVOCADO_EXTENSION_RELEASE_DIR", empty_release_dir),
+        ],
     );
 
     assert!(

--- a/tests/fixtures/extension-release.d/extension-release.gpu-driver
+++ b/tests/fixtures/extension-release.d/extension-release.gpu-driver
@@ -1,0 +1,5 @@
+ID=extension-release.gpu-driver
+VERSION_ID=2.0
+DESCRIPTION="GPU Driver Extension with Modules"
+AVOCADO_ON_MERGE=depmod
+AVOCADO_MODPROBE="nvidia i915 radeon"

--- a/tests/fixtures/extension-release.d/extension-release.network-driver
+++ b/tests/fixtures/extension-release.d/extension-release.network-driver
@@ -1,0 +1,5 @@
+ID=extension-release.network-driver
+VERSION_ID=1.0
+DESCRIPTION="Network Driver Extension"
+AVOCADO_ON_MERGE=depmod
+AVOCADO_MODPROBE="e1000e igb ixgbe"

--- a/tests/fixtures/extension-release.d/extension-release.sound-driver
+++ b/tests/fixtures/extension-release.d/extension-release.sound-driver
@@ -1,0 +1,4 @@
+ID=extension-release.sound-driver
+VERSION_ID=1.5
+DESCRIPTION="Sound Driver Extension"
+AVOCADO_MODPROBE=snd_hda_intel

--- a/tests/fixtures/extension-release.d/extension-release.storage-driver
+++ b/tests/fixtures/extension-release.d/extension-release.storage-driver
@@ -1,0 +1,5 @@
+ID=extension-release.storage-driver
+VERSION_ID=2.1
+DESCRIPTION="Storage Driver Extension"
+AVOCADO_ON_MERGE=depmod
+AVOCADO_MODPROBE="ahci nvme"

--- a/tests/fixtures/mock-modprobe
+++ b/tests/fixtures/mock-modprobe
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Mock modprobe command for testing
+echo "Mock modprobe: loading module $1"
+echo "Mock modprobe: module $1 loaded successfully"


### PR DESCRIPTION
system extensions can be configured in the avocado config to automatically call modprobe on kernel modules upon extension merge. This PR adds support for calling modprobe on all modules after the depmod call