### PR TITLE
Allow specifying mutability in avocadoctl config

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -1,0 +1,27 @@
+# Example avocadoctl configuration file
+# This file demonstrates the available configuration options
+
+[avocado.ext]
+# Directory where extensions are stored
+dir = "/var/lib/avocado/extensions"
+
+# Mutability mode for system extensions - sysext (/usr, /opt)
+# Valid values: no, auto, yes, import, ephemeral, ephemeral-import
+# Default: ephemeral
+sysext_mutable = "ephemeral"
+
+# Mutability mode for configuration extensions - confext (/etc)
+# Valid values: no, auto, yes, import, ephemeral, ephemeral-import
+# Default: ephemeral
+confext_mutable = "ephemeral"
+
+# Legacy option (deprecated, use sysext_mutable and confext_mutable instead)
+# If specified, applies to both sysext and confext unless overridden
+# mutable = "ephemeral"
+
+# Examples of different configurations:
+# sysext_mutable = "no"           # Force immutable mode for /usr, /opt
+# confext_mutable = "yes"         # Force mutable mode for /etc, create write routing directories
+# sysext_mutable = "auto"         # Enable mutable mode for /usr, /opt if write routing directories present
+# confext_mutable = "import"      # Immutable mode for /etc but merge write routing contents
+# sysext_mutable = "ephemeral-import" # Mutable mode for /usr, /opt with write routing merged but changes discarded after unmerge

--- a/src/commands/hitl.rs
+++ b/src/commands/hitl.rs
@@ -136,7 +136,8 @@ fn mount_extensions(matches: &ArgMatches, output: &OutputManager) {
             "HITL Mount",
             "Refreshing extensions to apply mounted changes",
         );
-        ext::refresh_extensions(output);
+        let config = crate::config::Config::default();
+        ext::refresh_extensions(&config, output);
     } else {
         output.error("HITL Mount", "Some extensions failed to mount");
         std::process::exit(1);
@@ -263,7 +264,8 @@ fn unmount_extensions(matches: &ArgMatches, output: &OutputManager) {
         output.success("HITL Unmount", "All extensions unmounted successfully");
         output.info("HITL Unmount", "Refreshing extensions to apply changes");
         // Step 3: Merge remaining extensions
-        ext::merge_extensions(output);
+        let config = crate::config::Config::default();
+        ext::merge_extensions(&config, output);
     } else {
         output.error("HITL Unmount", "Some extensions failed to unmount");
         std::process::exit(1);


### PR DESCRIPTION
Current behavior is to merge `/usr` `/opt` and `/etc` with an ephemeral upper r/w layer. In this configuration, runtime changes to these directories will be lost after a reboot. This PR allows configuring the `--mutable=` value from avocado config
```toml
# /etc/avocado/avocadoctl.conf

# Example avocadoctl configuration file
# This file demonstrates the available configuration options

[avocado.ext]
# Directory where extensions are stored
dir = "/var/lib/avocado/extensions"

# Mutability mode for extensions (systemd --mutable option)
# Valid values: no, auto, yes, import, ephemeral, ephemeral-import
# Default: ephemeral
mutable = "ephemeral"

# Examples of other valid values:
# mutable = "no"           # Force immutable mode
# mutable = "auto"         # Enable mutable mode if write routing directories present
# mutable = "yes"          # Force mutable mode, create write routing directories
# mutable = "import"       # Immutable mode but merge write routing contents
# mutable = "ephemeral-import" # Mutable mode with write routing merged but changes discarded after unmerge
```

More information on `mutable` at the [systemd docs](https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html)