### PR TITLE
release: avocadoctl 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocadoctl"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocadoctl"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Avocado Linux control CLI tool"
 authors = ["Avocado"]

--- a/src/commands/runtime.rs
+++ b/src/commands/runtime.rs
@@ -53,6 +53,7 @@ pub fn create_command() -> Command {
                     ),
                 ),
         )
+        .subcommand(Command::new("gc").about("Remove old runtimes and unreferenced images"))
         .subcommand(
             Command::new("metadata")
                 .about("Manage runtime metadata key-value pairs")
@@ -115,6 +116,9 @@ pub fn handle_command(matches: &ArgMatches, config: &Config, output: &OutputMana
         }
         Some(("inspect", inspect_matches)) => {
             handle_inspect(inspect_matches, config, output);
+        }
+        Some(("gc", _)) => {
+            handle_gc(config, output);
         }
         Some(("metadata", meta_matches)) => {
             handle_metadata(meta_matches, config, output);
@@ -524,6 +528,45 @@ fn resolve_runtime_id<'a>(
                     ids.join("\n")
                 ),
             );
+            std::process::exit(1);
+        }
+    }
+}
+
+fn handle_gc(config: &Config, output: &OutputManager) {
+    match crate::service::runtime::garbage_collect(config) {
+        Ok(result) => {
+            if output.is_json() {
+                let json = serde_json::json!({
+                    "removed_runtimes": result.removed_runtimes,
+                    "removed_images": result.removed_images,
+                });
+                println!("{}", serde_json::to_string_pretty(&json).unwrap());
+                return;
+            }
+            if result.removed_runtimes.is_empty() && result.removed_images.is_empty() {
+                output.info("Runtime GC", "Nothing to clean up.");
+            } else {
+                for id in &result.removed_runtimes {
+                    let short_id = &id[..8.min(id.len())];
+                    println!("  Removed runtime: {short_id}");
+                }
+                for img in &result.removed_images {
+                    println!("  Removed image: {img}");
+                }
+                println!();
+                output.success(
+                    "Runtime GC",
+                    &format!(
+                        "Removed {} runtime(s), {} image(s)",
+                        result.removed_runtimes.len(),
+                        result.removed_images.len(),
+                    ),
+                );
+            }
+        }
+        Err(e) => {
+            output.error("Runtime GC", &format!("{e}"));
             std::process::exit(1);
         }
     }

--- a/src/commands/runtime.rs
+++ b/src/commands/runtime.rs
@@ -53,6 +53,50 @@ pub fn create_command() -> Command {
                     ),
                 ),
         )
+        .subcommand(
+            Command::new("metadata")
+                .about("Manage runtime metadata key-value pairs")
+                .subcommand(
+                    Command::new("set")
+                        .about("Set a metadata key-value pair")
+                        .arg(
+                            Arg::new("id")
+                                .required(true)
+                                .help("Runtime build ID (full or prefix)"),
+                        )
+                        .arg(Arg::new("key").required(true).help("Metadata key"))
+                        .arg(Arg::new("value").required(true).help("Metadata value")),
+                )
+                .subcommand(
+                    Command::new("get")
+                        .about("Get a metadata value by key")
+                        .arg(
+                            Arg::new("id")
+                                .required(true)
+                                .help("Runtime build ID (full or prefix)"),
+                        )
+                        .arg(Arg::new("key").required(true).help("Metadata key")),
+                )
+                .subcommand(
+                    Command::new("list")
+                        .about("List all metadata for a runtime")
+                        .arg(
+                            Arg::new("id")
+                                .required(true)
+                                .help("Runtime build ID (full or prefix)"),
+                        ),
+                )
+                .subcommand(
+                    Command::new("delete")
+                        .about("Delete a metadata key")
+                        .arg(
+                            Arg::new("id")
+                                .required(true)
+                                .help("Runtime build ID (full or prefix)"),
+                        )
+                        .arg(Arg::new("key").required(true).help("Metadata key")),
+                ),
+        )
 }
 
 pub fn handle_command(matches: &ArgMatches, config: &Config, output: &OutputManager) {
@@ -71,6 +115,9 @@ pub fn handle_command(matches: &ArgMatches, config: &Config, output: &OutputMana
         }
         Some(("inspect", inspect_matches)) => {
             handle_inspect(inspect_matches, config, output);
+        }
+        Some(("metadata", meta_matches)) => {
+            handle_metadata(meta_matches, config, output);
         }
         _ => {
             println!("Use 'runtime list' to see available runtimes.");
@@ -477,6 +524,117 @@ fn resolve_runtime_id<'a>(
                     ids.join("\n")
                 ),
             );
+            std::process::exit(1);
+        }
+    }
+}
+
+fn handle_metadata(matches: &ArgMatches, config: &Config, output: &OutputManager) {
+    match matches.subcommand() {
+        Some(("set", set_matches)) => handle_metadata_set(set_matches, config, output),
+        Some(("get", get_matches)) => handle_metadata_get(get_matches, config, output),
+        Some(("list", list_matches)) => handle_metadata_list(list_matches, config, output),
+        Some(("delete", del_matches)) => handle_metadata_delete(del_matches, config, output),
+        _ => {
+            println!("Use 'avocadoctl runtime metadata --help' for available commands.");
+        }
+    }
+}
+
+fn handle_metadata_set(matches: &ArgMatches, config: &Config, output: &OutputManager) {
+    let id = matches.get_one::<String>("id").expect("id is required");
+    let key = matches.get_one::<String>("key").expect("key is required");
+    let value = matches
+        .get_one::<String>("value")
+        .expect("value is required");
+
+    match crate::service::runtime::metadata_set(id, key, value, config) {
+        Ok(()) => {
+            if output.is_json() {
+                println!("{{\"status\":\"ok\"}}");
+            } else {
+                output.success("Metadata Set", &format!("Set '{key}' on runtime {id}"));
+            }
+        }
+        Err(e) => {
+            output.error("Metadata Set", &format!("{e}"));
+            std::process::exit(1);
+        }
+    }
+}
+
+fn handle_metadata_get(matches: &ArgMatches, config: &Config, output: &OutputManager) {
+    let id = matches.get_one::<String>("id").expect("id is required");
+    let key = matches.get_one::<String>("key").expect("key is required");
+
+    match crate::service::runtime::metadata_get(id, key, config) {
+        Ok(value) => {
+            if output.is_json() {
+                println!("{}", serde_json::json!({"key": key, "value": value}));
+            } else {
+                println!("{value}");
+            }
+        }
+        Err(e) => {
+            output.error("Metadata Get", &format!("{e}"));
+            std::process::exit(1);
+        }
+    }
+}
+
+fn handle_metadata_list(matches: &ArgMatches, config: &Config, output: &OutputManager) {
+    let id = matches.get_one::<String>("id").expect("id is required");
+
+    match crate::service::runtime::metadata_list(id, config) {
+        Ok(entries) => {
+            if output.is_json() {
+                let json_entries: Vec<serde_json::Value> = entries
+                    .iter()
+                    .map(|(k, v)| serde_json::json!({"key": k, "value": v}))
+                    .collect();
+                println!("{}", serde_json::to_string_pretty(&json_entries).unwrap());
+            } else if entries.is_empty() {
+                output.info("Metadata List", "No metadata set for this runtime.");
+            } else {
+                let key_width = entries
+                    .iter()
+                    .map(|(k, _)| k.len())
+                    .max()
+                    .unwrap_or(3)
+                    .max(3);
+
+                println!();
+                println!("  {:<kw$} VALUE", "KEY", kw = key_width);
+                for (k, v) in &entries {
+                    println!("  {:<kw$} {v}", k, kw = key_width);
+                }
+                println!();
+            }
+        }
+        Err(e) => {
+            output.error("Metadata List", &format!("{e}"));
+            std::process::exit(1);
+        }
+    }
+}
+
+fn handle_metadata_delete(matches: &ArgMatches, config: &Config, output: &OutputManager) {
+    let id = matches.get_one::<String>("id").expect("id is required");
+    let key = matches.get_one::<String>("key").expect("key is required");
+
+    match crate::service::runtime::metadata_delete(id, key, config) {
+        Ok(()) => {
+            if output.is_json() {
+                println!("{{\"status\":\"ok\"}}");
+            } else {
+                output.success(
+                    "Metadata Delete",
+                    &format!("Deleted '{key}' from runtime {id}"),
+                );
+            }
+        }
+        Err(e) => {
+            output.error("Metadata Delete", &format!("{e}"));
             std::process::exit(1);
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,9 @@ pub struct AvocadoConfig {
     /// Update settings (streaming, etc.)
     #[serde(default)]
     pub update: UpdateSettings,
+    /// Garbage collection settings
+    #[serde(default)]
+    pub gc: GcSettings,
 }
 
 /// Update configuration
@@ -37,6 +40,28 @@ pub struct UpdateSettings {
     /// Default: false
     #[serde(default)]
     pub stream_os_to_partition: bool,
+}
+
+/// Garbage collection configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GcSettings {
+    /// Maximum number of runtimes to keep (including the active one).
+    /// The active runtime and any runtime referenced by a pending OS update are always kept.
+    /// Minimum: 1 (always keep the active runtime). Default: 3.
+    #[serde(default = "default_runtime_retention")]
+    pub runtime_retention: u32,
+}
+
+impl Default for GcSettings {
+    fn default() -> Self {
+        Self {
+            runtime_retention: default_runtime_retention(),
+        }
+    }
+}
+
+fn default_runtime_retention() -> u32 {
+    3
 }
 
 /// Extension configuration
@@ -75,6 +100,7 @@ impl Default for Config {
                 runtimes_dir: None,
                 socket: None,
                 update: UpdateSettings::default(),
+                gc: GcSettings::default(),
             },
         }
     }
@@ -143,6 +169,11 @@ impl Config {
     /// Get the spot check size in bytes for integrity hashing during merge.
     pub fn get_spot_check_bytes(&self) -> u64 {
         self.avocado.ext.spot_check_bytes
+    }
+
+    /// Get the runtime retention count, clamped to a minimum of 1.
+    pub fn runtime_retention(&self) -> u32 {
+        self.avocado.gc.runtime_retention.max(1)
     }
 
     /// Get the sysext mutable mode, defaulting to "ephemeral" if not set
@@ -567,6 +598,54 @@ mutable = "yes"
         assert!(error_message.contains("Invalid mutable value 'invalid_value'"));
         assert!(error_message
             .contains("Must be one of: no, auto, yes, import, ephemeral, ephemeral-import"));
+    }
+
+    #[test]
+    fn test_runtime_retention_default() {
+        let config = Config::default();
+        assert_eq!(config.runtime_retention(), 3);
+    }
+
+    #[test]
+    fn test_runtime_retention_clamps_to_min_1() {
+        let mut config = Config::default();
+        config.avocado.gc.runtime_retention = 0;
+        assert_eq!(config.runtime_retention(), 1);
+    }
+
+    #[test]
+    fn test_runtime_retention_from_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("gc_test.toml");
+
+        let config_content = r#"
+[avocado.ext]
+dir = "/var/lib/avocado/images"
+
+[avocado.gc]
+runtime_retention = 5
+"#;
+
+        fs::write(&config_path, config_content).unwrap();
+
+        let config = Config::load(&config_path).unwrap();
+        assert_eq!(config.runtime_retention(), 5);
+    }
+
+    #[test]
+    fn test_gc_defaults_when_omitted() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("no_gc_test.toml");
+
+        let config_content = r#"
+[avocado.ext]
+dir = "/var/lib/avocado/images"
+"#;
+
+        fs::write(&config_path, config_content).unwrap();
+
+        let config = Config::load(&config_path).unwrap();
+        assert_eq!(config.runtime_retention(), 3);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,14 +50,24 @@ pub struct GcSettings {
     /// Minimum: 1 (always keep the active runtime). Default: 3.
     #[serde(default = "default_runtime_retention")]
     pub runtime_retention: u32,
+    /// Whether to automatically run garbage collection after adding a runtime.
+    /// When false, GC only runs when explicitly invoked via `avocadoctl runtime gc`.
+    /// Default: true.
+    #[serde(default = "default_auto_gc")]
+    pub auto_gc: bool,
 }
 
 impl Default for GcSettings {
     fn default() -> Self {
         Self {
             runtime_retention: default_runtime_retention(),
+            auto_gc: default_auto_gc(),
         }
     }
+}
+
+fn default_auto_gc() -> bool {
+    true
 }
 
 fn default_runtime_retention() -> u32 {
@@ -174,6 +184,11 @@ impl Config {
     /// Get the runtime retention count, clamped to a minimum of 1.
     pub fn runtime_retention(&self) -> u32 {
         self.avocado.gc.runtime_retention.max(1)
+    }
+
+    /// Whether automatic GC after runtime add is enabled.
+    pub fn auto_gc(&self) -> bool {
+        self.avocado.gc.auto_gc
     }
 
     /// Get the sysext mutable mode, defaulting to "ephemeral" if not set
@@ -646,6 +661,32 @@ dir = "/var/lib/avocado/images"
 
         let config = Config::load(&config_path).unwrap();
         assert_eq!(config.runtime_retention(), 3);
+        assert!(config.auto_gc());
+    }
+
+    #[test]
+    fn test_auto_gc_default_true() {
+        let config = Config::default();
+        assert!(config.auto_gc());
+    }
+
+    #[test]
+    fn test_auto_gc_disabled_from_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("auto_gc_test.toml");
+
+        let config_content = r#"
+[avocado.ext]
+dir = "/var/lib/avocado/images"
+
+[avocado.gc]
+auto_gc = false
+"#;
+
+        fs::write(&config_path, config_content).unwrap();
+
+        let config = Config::load(&config_path).unwrap();
+        assert!(!config.auto_gc());
     }
 
     #[test]

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,0 +1,432 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+use crate::manifest::{RuntimeManifest, IMAGES_DIR_NAME};
+use crate::staging::{self, StagingError};
+
+/// Result of a garbage collection run.
+#[derive(Debug, Clone, Default)]
+pub struct GcResult {
+    /// IDs of runtimes that were removed.
+    pub removed_runtimes: Vec<String>,
+    /// Filenames of images that were removed from the shared pool.
+    pub removed_images: Vec<String>,
+}
+
+/// Run garbage collection: remove old runtimes and unreferenced images.
+///
+/// Keeps at most `retention` runtimes. The active runtime and any runtime
+/// referenced by `pending-update.json` are always kept regardless of the limit.
+pub fn collect_garbage(base_dir: &Path, retention: u32) -> Result<GcResult, StagingError> {
+    let retention = retention.max(1) as usize;
+    let mut result = GcResult::default();
+
+    // 1. Load all runtimes, sorted: active first, then by built_at DESC
+    let runtimes = RuntimeManifest::list_all(base_dir);
+    if runtimes.len() <= retention {
+        // Still clean up orphaned images even when no runtimes need removal
+        result.removed_images = cleanup_orphaned_images(base_dir, &runtimes);
+        return Ok(result);
+    }
+
+    // 2. Determine protected runtime IDs (always kept regardless of retention)
+    let mut protected: HashSet<String> = HashSet::new();
+
+    for (m, is_active) in &runtimes {
+        if *is_active {
+            protected.insert(m.id.clone());
+        }
+    }
+
+    // Protect any runtime referenced by pending-update.json
+    let pending_path = base_dir.join("pending-update.json");
+    if let Some(pending) = crate::os_update::read_pending_update_from(&pending_path) {
+        if let Some(ref rt_id) = pending.runtime_id {
+            protected.insert(rt_id.clone());
+        }
+    }
+
+    // 3. Build the keep set: iterate sorted list, add until retention reached
+    //    list_all is sorted active-first then by built_at DESC, so this
+    //    naturally keeps the active runtime and the newest inactive ones.
+    let mut keep: HashSet<String> = HashSet::new();
+    for (m, _) in &runtimes {
+        if keep.len() >= retention {
+            break;
+        }
+        keep.insert(m.id.clone());
+    }
+    // Ensure all protected runtimes are always in the keep set
+    keep.extend(protected);
+
+    // 4. Remove runtimes not in the keep set
+    for (m, _) in &runtimes {
+        if !keep.contains(&m.id) {
+            match staging::remove_runtime(&m.id, base_dir) {
+                Ok(()) => result.removed_runtimes.push(m.id.clone()),
+                Err(StagingError::RemoveActiveRuntime) => {
+                    // Shouldn't happen since we protect active, but skip gracefully
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    // 5. Clean up orphaned images
+    let surviving = RuntimeManifest::list_all(base_dir);
+    result.removed_images = cleanup_orphaned_images(base_dir, &surviving);
+
+    Ok(result)
+}
+
+/// Collect all image filenames referenced by the given runtimes, then scan
+/// the images directory and delete any files not in that set.
+/// Returns the list of deleted filenames.
+fn cleanup_orphaned_images(base_dir: &Path, runtimes: &[(RuntimeManifest, bool)]) -> Vec<String> {
+    let mut referenced: HashSet<String> = HashSet::new();
+
+    for (m, _) in runtimes {
+        for ext in &m.extensions {
+            // resolve_path gives us the full path; we only need the filename
+            let path = ext.resolve_path(base_dir);
+            if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
+                referenced.insert(filename.to_string());
+            }
+        }
+        if let Some(ref os_bundle) = m.os_bundle {
+            referenced.insert(format!("{}.raw", os_bundle.image_id));
+        }
+    }
+
+    let images_dir = base_dir.join(IMAGES_DIR_NAME);
+    let mut removed = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(&images_dir) {
+        for entry in entries.flatten() {
+            let filename = entry.file_name().to_string_lossy().to_string();
+            if !referenced.contains(&filename) && fs::remove_file(entry.path()).is_ok() {
+                removed.push(filename);
+            }
+        }
+    }
+
+    removed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{ManifestExtension, OsBundleRef, RuntimeInfo, RuntimeManifest};
+    use std::os::unix::fs as unix_fs;
+    use tempfile::TempDir;
+
+    fn make_manifest(id: &str, built_at: &str, image_id: &str) -> RuntimeManifest {
+        RuntimeManifest {
+            manifest_version: 1,
+            id: id.to_string(),
+            built_at: built_at.to_string(),
+            runtime: RuntimeInfo {
+                name: "dev".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            extensions: vec![ManifestExtension {
+                name: "app".to_string(),
+                version: "0.1.0".to_string(),
+                image_id: Some(image_id.to_string()),
+                image_type: None,
+                sha256: None,
+            }],
+            os_bundle: None,
+        }
+    }
+
+    fn write_manifest(base_dir: &Path, manifest: &RuntimeManifest) {
+        let dir = base_dir.join("runtimes").join(&manifest.id);
+        fs::create_dir_all(&dir).unwrap();
+        let json = serde_json::to_string_pretty(manifest).unwrap();
+        fs::write(dir.join("manifest.json"), json).unwrap();
+    }
+
+    fn write_image(base_dir: &Path, filename: &str) {
+        let images_dir = base_dir.join("images");
+        fs::create_dir_all(&images_dir).unwrap();
+        fs::write(images_dir.join(filename), b"image data").unwrap();
+    }
+
+    fn set_active(base_dir: &Path, id: &str) {
+        let link = base_dir.join("active");
+        let _ = fs::remove_file(&link);
+        unix_fs::symlink(format!("runtimes/{id}"), &link).unwrap();
+    }
+
+    fn write_pending_update(base_dir: &Path, runtime_id: &str) {
+        let pending = serde_json::json!({
+            "os_build_id": "test-os",
+            "verify": null,
+            "rollback": null,
+            "previous_slot": "a",
+            "runtime_id": runtime_id
+        });
+        fs::write(
+            base_dir.join("pending-update.json"),
+            serde_json::to_string_pretty(&pending).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_gc_noop_when_under_retention() {
+        let tmp = TempDir::new().unwrap();
+        let m1 = make_manifest("rt-1", "2026-01-01T00:00:00Z", "img-1");
+        let m2 = make_manifest("rt-2", "2026-01-02T00:00:00Z", "img-2");
+        write_manifest(tmp.path(), &m1);
+        write_manifest(tmp.path(), &m2);
+        set_active(tmp.path(), "rt-2");
+
+        let result = collect_garbage(tmp.path(), 3).unwrap();
+        assert!(result.removed_runtimes.is_empty());
+        // Both runtimes should still exist
+        assert!(tmp.path().join("runtimes/rt-1").exists());
+        assert!(tmp.path().join("runtimes/rt-2").exists());
+    }
+
+    #[test]
+    fn test_gc_removes_oldest_runtimes() {
+        let tmp = TempDir::new().unwrap();
+        let m1 = make_manifest("rt-1", "2026-01-01T00:00:00Z", "img-1");
+        let m2 = make_manifest("rt-2", "2026-01-02T00:00:00Z", "img-2");
+        let m3 = make_manifest("rt-3", "2026-01-03T00:00:00Z", "img-3");
+        let m4 = make_manifest("rt-4", "2026-01-04T00:00:00Z", "img-4");
+        let m5 = make_manifest("rt-5", "2026-01-05T00:00:00Z", "img-5");
+
+        for m in [&m1, &m2, &m3, &m4, &m5] {
+            write_manifest(tmp.path(), m);
+        }
+        set_active(tmp.path(), "rt-5");
+
+        let result = collect_garbage(tmp.path(), 3).unwrap();
+        assert_eq!(result.removed_runtimes.len(), 2);
+        assert!(result.removed_runtimes.contains(&"rt-1".to_string()));
+        assert!(result.removed_runtimes.contains(&"rt-2".to_string()));
+
+        // Kept: rt-5 (active), rt-4, rt-3
+        assert!(tmp.path().join("runtimes/rt-5").exists());
+        assert!(tmp.path().join("runtimes/rt-4").exists());
+        assert!(tmp.path().join("runtimes/rt-3").exists());
+        assert!(!tmp.path().join("runtimes/rt-1").exists());
+        assert!(!tmp.path().join("runtimes/rt-2").exists());
+    }
+
+    #[test]
+    fn test_gc_protects_active_runtime() {
+        let tmp = TempDir::new().unwrap();
+        let m1 = make_manifest("rt-1", "2026-01-01T00:00:00Z", "img-1");
+        let m2 = make_manifest("rt-2", "2026-01-02T00:00:00Z", "img-2");
+        write_manifest(tmp.path(), &m1);
+        write_manifest(tmp.path(), &m2);
+        set_active(tmp.path(), "rt-1"); // Active is the oldest
+
+        let result = collect_garbage(tmp.path(), 1).unwrap();
+        // rt-1 is active so it's protected; rt-2 is newest so it fills retention=1
+        // But active must be kept, so both may be kept depending on algorithm
+        // retention=1 means keep 1 runtime. Active-first sort means rt-1 fills the slot.
+        // rt-2 is not protected and exceeds retention.
+        assert_eq!(result.removed_runtimes.len(), 1);
+        assert!(result.removed_runtimes.contains(&"rt-2".to_string()));
+        assert!(tmp.path().join("runtimes/rt-1").exists());
+    }
+
+    #[test]
+    fn test_gc_protects_pending_update_runtime() {
+        let tmp = TempDir::new().unwrap();
+        let m1 = make_manifest("rt-1", "2026-01-01T00:00:00Z", "img-1");
+        let m2 = make_manifest("rt-2", "2026-01-02T00:00:00Z", "img-2");
+        let m3 = make_manifest("rt-3", "2026-01-03T00:00:00Z", "img-3");
+        let m4 = make_manifest("rt-4", "2026-01-04T00:00:00Z", "img-4");
+
+        for m in [&m1, &m2, &m3, &m4] {
+            write_manifest(tmp.path(), m);
+        }
+        set_active(tmp.path(), "rt-4");
+        write_pending_update(tmp.path(), "rt-1"); // Oldest is pending
+
+        // retention=2: keep rt-4 (active, newest), rt-3 (2nd newest)
+        // But rt-1 is protected by pending update, so it's also kept
+        let result = collect_garbage(tmp.path(), 2).unwrap();
+        assert_eq!(result.removed_runtimes.len(), 1);
+        assert!(result.removed_runtimes.contains(&"rt-2".to_string()));
+
+        assert!(tmp.path().join("runtimes/rt-4").exists());
+        assert!(tmp.path().join("runtimes/rt-3").exists());
+        assert!(tmp.path().join("runtimes/rt-1").exists()); // Protected
+        assert!(!tmp.path().join("runtimes/rt-2").exists());
+    }
+
+    #[test]
+    fn test_gc_cleans_orphaned_images() {
+        let tmp = TempDir::new().unwrap();
+        let m1 = make_manifest("rt-1", "2026-01-01T00:00:00Z", "img-1");
+        let m2 = make_manifest("rt-2", "2026-01-02T00:00:00Z", "img-2");
+        let m3 = make_manifest("rt-3", "2026-01-03T00:00:00Z", "img-shared");
+
+        for m in [&m1, &m2, &m3] {
+            write_manifest(tmp.path(), m);
+        }
+        set_active(tmp.path(), "rt-3");
+
+        // Write images: img-1 only used by rt-1, img-2 only by rt-2, img-shared by rt-3
+        write_image(tmp.path(), "img-1.raw");
+        write_image(tmp.path(), "img-2.raw");
+        write_image(tmp.path(), "img-shared.raw");
+        write_image(tmp.path(), "orphan.raw"); // Not referenced by any runtime
+
+        // retention=2: keep rt-3 (active), rt-2
+        let result = collect_garbage(tmp.path(), 2).unwrap();
+
+        assert_eq!(result.removed_runtimes.len(), 1);
+        assert!(result.removed_runtimes.contains(&"rt-1".to_string()));
+
+        // img-1.raw and orphan.raw should be removed (rt-1 removed, orphan unreferenced)
+        assert!(result.removed_images.contains(&"img-1.raw".to_string()));
+        assert!(result.removed_images.contains(&"orphan.raw".to_string()));
+        // img-2.raw and img-shared.raw should remain
+        assert!(tmp.path().join("images/img-2.raw").exists());
+        assert!(tmp.path().join("images/img-shared.raw").exists());
+        assert!(!tmp.path().join("images/img-1.raw").exists());
+        assert!(!tmp.path().join("images/orphan.raw").exists());
+    }
+
+    #[test]
+    fn test_gc_keeps_shared_images() {
+        let tmp = TempDir::new().unwrap();
+        // Both runtimes reference the same image
+        let m1 = make_manifest("rt-1", "2026-01-01T00:00:00Z", "shared-img");
+        let m2 = make_manifest("rt-2", "2026-01-02T00:00:00Z", "shared-img");
+        let m3 = make_manifest("rt-3", "2026-01-03T00:00:00Z", "img-3");
+
+        for m in [&m1, &m2, &m3] {
+            write_manifest(tmp.path(), m);
+        }
+        set_active(tmp.path(), "rt-3");
+        write_image(tmp.path(), "shared-img.raw");
+        write_image(tmp.path(), "img-3.raw");
+
+        // retention=2: keep rt-3, rt-2; remove rt-1
+        let result = collect_garbage(tmp.path(), 2).unwrap();
+
+        assert_eq!(result.removed_runtimes.len(), 1);
+        // shared-img.raw is still referenced by rt-2, so it should NOT be deleted
+        assert!(tmp.path().join("images/shared-img.raw").exists());
+        assert!(result.removed_images.is_empty());
+    }
+
+    #[test]
+    fn test_gc_retention_zero_clamps_to_one() {
+        let tmp = TempDir::new().unwrap();
+        let m1 = make_manifest("rt-1", "2026-01-01T00:00:00Z", "img-1");
+        let m2 = make_manifest("rt-2", "2026-01-02T00:00:00Z", "img-2");
+        write_manifest(tmp.path(), &m1);
+        write_manifest(tmp.path(), &m2);
+        set_active(tmp.path(), "rt-2");
+
+        let result = collect_garbage(tmp.path(), 0).unwrap();
+        // retention clamped to 1, keep only rt-2 (active + newest)
+        assert_eq!(result.removed_runtimes.len(), 1);
+        assert!(result.removed_runtimes.contains(&"rt-1".to_string()));
+        assert!(tmp.path().join("runtimes/rt-2").exists());
+    }
+
+    #[test]
+    fn test_gc_handles_no_active_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let m1 = make_manifest("rt-1", "2026-01-01T00:00:00Z", "img-1");
+        let m2 = make_manifest("rt-2", "2026-01-02T00:00:00Z", "img-2");
+        let m3 = make_manifest("rt-3", "2026-01-03T00:00:00Z", "img-3");
+
+        for m in [&m1, &m2, &m3] {
+            write_manifest(tmp.path(), m);
+        }
+        // No active symlink
+
+        let result = collect_garbage(tmp.path(), 2).unwrap();
+        // Sorted by built_at DESC: rt-3, rt-2, rt-1. Keep rt-3, rt-2.
+        assert_eq!(result.removed_runtimes.len(), 1);
+        assert!(result.removed_runtimes.contains(&"rt-1".to_string()));
+    }
+
+    #[test]
+    fn test_gc_handles_os_bundle_images() {
+        let tmp = TempDir::new().unwrap();
+        let mut m1 = make_manifest("rt-1", "2026-01-01T00:00:00Z", "img-1");
+        m1.os_bundle = Some(OsBundleRef {
+            image_id: "os-img-1".to_string(),
+            sha256: "abc".to_string(),
+            os_build_id: None,
+            initramfs_build_id: None,
+        });
+        let m2 = make_manifest("rt-2", "2026-01-02T00:00:00Z", "img-2");
+
+        write_manifest(tmp.path(), &m1);
+        write_manifest(tmp.path(), &m2);
+        set_active(tmp.path(), "rt-2");
+
+        write_image(tmp.path(), "img-1.raw");
+        write_image(tmp.path(), "img-2.raw");
+        write_image(tmp.path(), "os-img-1.raw");
+
+        // retention=1: keep only rt-2 (active); remove rt-1
+        let result = collect_garbage(tmp.path(), 1).unwrap();
+
+        assert!(result.removed_runtimes.contains(&"rt-1".to_string()));
+        // os-img-1.raw and img-1.raw should be removed
+        assert!(result.removed_images.contains(&"os-img-1.raw".to_string()));
+        assert!(result.removed_images.contains(&"img-1.raw".to_string()));
+        // img-2.raw should remain
+        assert!(tmp.path().join("images/img-2.raw").exists());
+    }
+
+    #[test]
+    fn test_gc_cleans_metadata_with_runtime() {
+        let tmp = TempDir::new().unwrap();
+        let m1 = make_manifest("rt-1", "2026-01-01T00:00:00Z", "img-1");
+        let m2 = make_manifest("rt-2", "2026-01-02T00:00:00Z", "img-2");
+        write_manifest(tmp.path(), &m1);
+        write_manifest(tmp.path(), &m2);
+        set_active(tmp.path(), "rt-2");
+
+        // Write metadata for rt-1
+        let rt1_dir = tmp.path().join("runtimes/rt-1");
+        let mut meta = crate::metadata::RuntimeMetadata::new();
+        meta.entries
+            .insert("env".to_string(), "staging".to_string());
+        meta.save(&rt1_dir).unwrap();
+        assert!(rt1_dir.join("metadata.json").exists());
+
+        let result = collect_garbage(tmp.path(), 1).unwrap();
+        assert!(result.removed_runtimes.contains(&"rt-1".to_string()));
+        // metadata.json should be gone along with the runtime directory
+        assert!(!rt1_dir.exists());
+        assert!(!rt1_dir.join("metadata.json").exists());
+    }
+
+    #[test]
+    fn test_gc_handles_kab_images() {
+        let tmp = TempDir::new().unwrap();
+        let mut m1 = make_manifest("rt-1", "2026-01-01T00:00:00Z", "img-1");
+        m1.extensions[0].image_type = Some("kab".to_string());
+        let m2 = make_manifest("rt-2", "2026-01-02T00:00:00Z", "img-2");
+
+        write_manifest(tmp.path(), &m1);
+        write_manifest(tmp.path(), &m2);
+        set_active(tmp.path(), "rt-2");
+
+        write_image(tmp.path(), "img-1.kab");
+        write_image(tmp.path(), "img-2.raw");
+
+        let result = collect_garbage(tmp.path(), 1).unwrap();
+        assert!(result.removed_images.contains(&"img-1.kab".to_string()));
+        assert!(tmp.path().join("images/img-2.raw").exists());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod config;
+pub mod gc;
 pub mod hash;
 pub mod manifest;
 pub mod metadata;
@@ -404,6 +405,43 @@ fn main() {
                     let mut client = vl_rt::VarlinkClient::new(conn);
                     match client.inspect(id).call() {
                         Ok(reply) => varlink_client::print_runtime_detail(&reply.runtime, &output),
+                        Err(e) => varlink_client::exit_with_rpc_error(e, &output),
+                    }
+                }
+                Some(("gc", _)) => {
+                    let mut client = vl_rt::VarlinkClient::new(conn);
+                    match client.garbage_collect().call() {
+                        Ok(reply) => {
+                            let result = &reply.result;
+                            if output.is_json() {
+                                let json = serde_json::json!({
+                                    "removed_runtimes": result.removedRuntimes,
+                                    "removed_images": result.removedImages,
+                                });
+                                println!("{}", serde_json::to_string_pretty(&json).unwrap());
+                            } else if result.removedRuntimes.is_empty()
+                                && result.removedImages.is_empty()
+                            {
+                                output.info("Runtime GC", "Nothing to clean up.");
+                            } else {
+                                for id in &result.removedRuntimes {
+                                    let short_id = &id[..8.min(id.len())];
+                                    println!("  Removed runtime: {short_id}");
+                                }
+                                for img in &result.removedImages {
+                                    println!("  Removed image: {img}");
+                                }
+                                println!();
+                                output.success(
+                                    "Runtime GC",
+                                    &format!(
+                                        "Removed {} runtime(s), {} image(s)",
+                                        result.removedRuntimes.len(),
+                                        result.removedImages.len(),
+                                    ),
+                                );
+                            }
+                        }
                         Err(e) => varlink_client::exit_with_rpc_error(e, &output),
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod commands;
 mod config;
 pub mod hash;
 pub mod manifest;
+pub mod metadata;
 pub mod os_update;
 mod output;
 pub mod service;
@@ -404,6 +405,96 @@ fn main() {
                     match client.inspect(id).call() {
                         Ok(reply) => varlink_client::print_runtime_detail(&reply.runtime, &output),
                         Err(e) => varlink_client::exit_with_rpc_error(e, &output),
+                    }
+                }
+                Some(("metadata", meta_matches)) => {
+                    let mut client = vl_rt::VarlinkClient::new(conn);
+                    match meta_matches.subcommand() {
+                        Some(("set", set_matches)) => {
+                            let id = set_matches
+                                .get_one::<String>("id")
+                                .expect("id is required")
+                                .clone();
+                            let key = set_matches
+                                .get_one::<String>("key")
+                                .expect("key is required")
+                                .clone();
+                            let value = set_matches
+                                .get_one::<String>("value")
+                                .expect("value is required")
+                                .clone();
+                            match client.metadata_set(id.clone(), key.clone(), value).call() {
+                                Ok(_) => {
+                                    if output.is_json() {
+                                        println!("{{\"status\":\"ok\"}}");
+                                    } else {
+                                        output.success(
+                                            "Metadata Set",
+                                            &format!("Set '{key}' on runtime {id}"),
+                                        );
+                                    }
+                                }
+                                Err(e) => varlink_client::exit_with_rpc_error(e, &output),
+                            }
+                        }
+                        Some(("get", get_matches)) => {
+                            let id = get_matches
+                                .get_one::<String>("id")
+                                .expect("id is required")
+                                .clone();
+                            let key = get_matches
+                                .get_one::<String>("key")
+                                .expect("key is required")
+                                .clone();
+                            match client.metadata_get(id, key.clone()).call() {
+                                Ok(reply) => varlink_client::print_metadata_value(
+                                    &key,
+                                    &reply.value,
+                                    &output,
+                                ),
+                                Err(e) => varlink_client::exit_with_rpc_error(e, &output),
+                            }
+                        }
+                        Some(("list", list_matches)) => {
+                            let id = list_matches
+                                .get_one::<String>("id")
+                                .expect("id is required")
+                                .clone();
+                            match client.metadata_list(id).call() {
+                                Ok(reply) => {
+                                    varlink_client::print_metadata_list(&reply.entries, &output)
+                                }
+                                Err(e) => varlink_client::exit_with_rpc_error(e, &output),
+                            }
+                        }
+                        Some(("delete", del_matches)) => {
+                            let id = del_matches
+                                .get_one::<String>("id")
+                                .expect("id is required")
+                                .clone();
+                            let key = del_matches
+                                .get_one::<String>("key")
+                                .expect("key is required")
+                                .clone();
+                            match client.metadata_delete(id.clone(), key.clone()).call() {
+                                Ok(_) => {
+                                    if output.is_json() {
+                                        println!("{{\"status\":\"ok\"}}");
+                                    } else {
+                                        output.success(
+                                            "Metadata Delete",
+                                            &format!("Deleted '{key}' from runtime {id}"),
+                                        );
+                                    }
+                                }
+                                Err(e) => varlink_client::exit_with_rpc_error(e, &output),
+                            }
+                        }
+                        _ => {
+                            println!(
+                                "Use 'avocadoctl runtime metadata --help' for available commands."
+                            );
+                        }
                     }
                 }
                 _ => {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -7,6 +7,7 @@ pub const ACTIVE_LINK_NAME: &str = "active";
 pub const RUNTIMES_DIR_NAME: &str = "runtimes";
 pub const MANIFEST_FILENAME: &str = "manifest.json";
 pub const IMAGES_DIR_NAME: &str = "images";
+pub const METADATA_FILENAME: &str = "metadata.json";
 
 /// Fixed namespace UUID for generating content-addressable image IDs.
 /// Must match the constant used in avocado-cli.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,112 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use crate::manifest::METADATA_FILENAME;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeMetadata {
+    pub version: u32,
+    pub entries: HashMap<String, String>,
+}
+
+impl RuntimeMetadata {
+    /// Create an empty metadata store.
+    pub fn new() -> Self {
+        Self {
+            version: 1,
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Load metadata from a runtime directory. Returns empty metadata if the file
+    /// is missing or corrupt (graceful degradation).
+    pub fn load(runtime_dir: &Path) -> Self {
+        let path = runtime_dir.join(METADATA_FILENAME);
+        match fs::read_to_string(&path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_else(|_| Self::new()),
+            Err(_) => Self::new(),
+        }
+    }
+
+    /// Save metadata to a runtime directory.
+    pub fn save(&self, runtime_dir: &Path) -> Result<(), std::io::Error> {
+        let path = runtime_dir.join(METADATA_FILENAME);
+        let json = serde_json::to_string_pretty(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        fs::write(&path, json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_new_is_empty() {
+        let meta = RuntimeMetadata::new();
+        assert_eq!(meta.version, 1);
+        assert!(meta.entries.is_empty());
+    }
+
+    #[test]
+    fn test_load_missing_file_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let meta = RuntimeMetadata::load(tmp.path());
+        assert_eq!(meta.version, 1);
+        assert!(meta.entries.is_empty());
+    }
+
+    #[test]
+    fn test_load_corrupt_file_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(METADATA_FILENAME), "not json").unwrap();
+        let meta = RuntimeMetadata::load(tmp.path());
+        assert_eq!(meta.version, 1);
+        assert!(meta.entries.is_empty());
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let mut meta = RuntimeMetadata::new();
+        meta.entries.insert("foo".to_string(), "bar".to_string());
+        meta.entries
+            .insert("environment".to_string(), "staging".to_string());
+
+        meta.save(tmp.path()).unwrap();
+        let loaded = RuntimeMetadata::load(tmp.path());
+        assert_eq!(loaded.version, 1);
+        assert_eq!(loaded.entries.len(), 2);
+        assert_eq!(loaded.entries.get("foo").unwrap(), "bar");
+        assert_eq!(loaded.entries.get("environment").unwrap(), "staging");
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let mut meta = RuntimeMetadata::new();
+        meta.entries.insert("key".to_string(), "value".to_string());
+
+        let json = serde_json::to_string(&meta).unwrap();
+        let parsed: RuntimeMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.version, 1);
+        assert_eq!(parsed.entries.get("key").unwrap(), "value");
+    }
+
+    #[test]
+    fn test_overwrite_existing() {
+        let tmp = TempDir::new().unwrap();
+        let mut meta = RuntimeMetadata::new();
+        meta.entries.insert("k".to_string(), "v1".to_string());
+        meta.save(tmp.path()).unwrap();
+
+        let mut meta2 = RuntimeMetadata::load(tmp.path());
+        meta2.entries.insert("k".to_string(), "v2".to_string());
+        meta2.save(tmp.path()).unwrap();
+
+        let loaded = RuntimeMetadata::load(tmp.path());
+        assert_eq!(loaded.entries.get("k").unwrap(), "v2");
+    }
+}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -11,13 +11,19 @@ pub struct RuntimeMetadata {
     pub entries: HashMap<String, String>,
 }
 
-impl RuntimeMetadata {
-    /// Create an empty metadata store.
-    pub fn new() -> Self {
+impl Default for RuntimeMetadata {
+    fn default() -> Self {
         Self {
             version: 1,
             entries: HashMap::new(),
         }
+    }
+}
+
+impl RuntimeMetadata {
+    /// Create an empty metadata store.
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Load metadata from a runtime directory. Returns empty metadata if the file
@@ -33,8 +39,7 @@ impl RuntimeMetadata {
     /// Save metadata to a runtime directory.
     pub fn save(&self, runtime_dir: &Path) -> Result<(), std::io::Error> {
         let path = runtime_dir.join(METADATA_FILENAME);
-        let json = serde_json::to_string_pretty(self)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let json = serde_json::to_string_pretty(self).map_err(std::io::Error::other)?;
         fs::write(&path, json)
     }
 }

--- a/src/service/error.rs
+++ b/src/service/error.rs
@@ -53,6 +53,9 @@ pub enum AvocadoError {
     #[error("No root authority configured")]
     NoRootAuthority,
 
+    #[error("Metadata key '{key}' not found for runtime '{id}'")]
+    MetadataKeyNotFound { id: String, key: String },
+
     #[error("Parse failed: {reason}")]
     ParseFailed { reason: String },
 

--- a/src/service/runtime.rs
+++ b/src/service/runtime.rs
@@ -96,8 +96,9 @@ pub fn add_from_url_streaming(
             "OS update applied. Rebooting to activate new OS...",
         ));
     }
-    // Best-effort GC after successful add
-    let _ = garbage_collect(config);
+    if config.auto_gc() {
+        let _ = garbage_collect(config);
+    }
     Ok(super::ext::refresh_extensions_streaming(config))
 }
 
@@ -132,8 +133,9 @@ pub fn add_from_manifest_streaming(
     }
 
     staging::activate_runtime(&manifest.id, base_path)?;
-    // Best-effort GC after successful add
-    let _ = garbage_collect(config);
+    if config.auto_gc() {
+        let _ = garbage_collect(config);
+    }
     Ok(super::ext::refresh_extensions_streaming(config))
 }
 
@@ -203,8 +205,9 @@ pub fn add_from_url(
         ]);
     }
     let result = super::ext::refresh_extensions(config);
-    // Best-effort GC after successful add
-    let _ = garbage_collect(config);
+    if config.auto_gc() {
+        let _ = garbage_collect(config);
+    }
     result
 }
 
@@ -240,8 +243,9 @@ pub fn add_from_manifest(
 
     staging::activate_runtime(&manifest.id, base_path)?;
     let result = super::ext::refresh_extensions(config);
-    // Best-effort GC after successful add
-    let _ = garbage_collect(config);
+    if config.auto_gc() {
+        let _ = garbage_collect(config);
+    }
     result
 }
 

--- a/src/service/runtime.rs
+++ b/src/service/runtime.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::gc;
 use crate::manifest::{RuntimeManifest, IMAGES_DIR_NAME};
 use crate::service::error::AvocadoError;
 use crate::service::types::{RuntimeEntry, RuntimeExtensionInfo};
@@ -95,6 +96,8 @@ pub fn add_from_url_streaming(
             "OS update applied. Rebooting to activate new OS...",
         ));
     }
+    // Best-effort GC after successful add
+    let _ = garbage_collect(config);
     Ok(super::ext::refresh_extensions_streaming(config))
 }
 
@@ -129,6 +132,8 @@ pub fn add_from_manifest_streaming(
     }
 
     staging::activate_runtime(&manifest.id, base_path)?;
+    // Best-effort GC after successful add
+    let _ = garbage_collect(config);
     Ok(super::ext::refresh_extensions_streaming(config))
 }
 
@@ -197,7 +202,10 @@ pub fn add_from_url(
             "OS update applied. Rebooting to activate new OS.".to_string()
         ]);
     }
-    super::ext::refresh_extensions(config)
+    let result = super::ext::refresh_extensions(config);
+    // Best-effort GC after successful add
+    let _ = garbage_collect(config);
+    result
 }
 
 /// Add a runtime from a local manifest file.
@@ -231,7 +239,10 @@ pub fn add_from_manifest(
     }
 
     staging::activate_runtime(&manifest.id, base_path)?;
-    super::ext::refresh_extensions(config)
+    let result = super::ext::refresh_extensions(config);
+    // Best-effort GC after successful add
+    let _ = garbage_collect(config);
+    result
 }
 
 /// Remove a staged runtime by ID (or prefix).
@@ -365,6 +376,16 @@ fn runtime_requires_os_change(
     })?;
 
     Ok(true)
+}
+
+// ── Garbage collection ─────────────────────────────────────────────────────
+
+/// Run garbage collection to remove old runtimes and unreferenced images.
+pub fn garbage_collect(config: &Config) -> Result<gc::GcResult, AvocadoError> {
+    let base_dir = config.get_avocado_base_dir();
+    let base_path = Path::new(&base_dir);
+    let retention = config.runtime_retention();
+    gc::collect_garbage(base_path, retention).map_err(|e| e.into())
 }
 
 // ── Metadata service functions ──────────────────────────────────────────────

--- a/src/service/runtime.rs
+++ b/src/service/runtime.rs
@@ -367,6 +367,90 @@ fn runtime_requires_os_change(
     Ok(true)
 }
 
+// ── Metadata service functions ──────────────────────────────────────────────
+
+/// Set a metadata key-value pair on a runtime.
+pub fn metadata_set(
+    id_prefix: &str,
+    key: &str,
+    value: &str,
+    config: &Config,
+) -> Result<(), AvocadoError> {
+    let base_dir = config.get_avocado_base_dir();
+    let base_path = Path::new(&base_dir);
+    let runtimes = RuntimeManifest::list_all(base_path);
+    let matched = resolve_runtime(id_prefix, &runtimes)?;
+
+    let runtime_dir = base_path.join("runtimes").join(&matched.id);
+    let mut metadata = crate::metadata::RuntimeMetadata::load(&runtime_dir);
+    metadata.entries.insert(key.to_string(), value.to_string());
+    metadata
+        .save(&runtime_dir)
+        .map_err(|e| AvocadoError::StagingFailed {
+            reason: format!("Failed to save metadata: {e}"),
+        })?;
+    Ok(())
+}
+
+/// Get a metadata value by key.
+pub fn metadata_get(id_prefix: &str, key: &str, config: &Config) -> Result<String, AvocadoError> {
+    let base_dir = config.get_avocado_base_dir();
+    let base_path = Path::new(&base_dir);
+    let runtimes = RuntimeManifest::list_all(base_path);
+    let matched = resolve_runtime(id_prefix, &runtimes)?;
+
+    let runtime_dir = base_path.join("runtimes").join(&matched.id);
+    let metadata = crate::metadata::RuntimeMetadata::load(&runtime_dir);
+    metadata
+        .entries
+        .get(key)
+        .cloned()
+        .ok_or_else(|| AvocadoError::MetadataKeyNotFound {
+            id: matched.id.clone(),
+            key: key.to_string(),
+        })
+}
+
+/// List all metadata for a runtime.
+pub fn metadata_list(
+    id_prefix: &str,
+    config: &Config,
+) -> Result<Vec<(String, String)>, AvocadoError> {
+    let base_dir = config.get_avocado_base_dir();
+    let base_path = Path::new(&base_dir);
+    let runtimes = RuntimeManifest::list_all(base_path);
+    let matched = resolve_runtime(id_prefix, &runtimes)?;
+
+    let runtime_dir = base_path.join("runtimes").join(&matched.id);
+    let metadata = crate::metadata::RuntimeMetadata::load(&runtime_dir);
+    let mut entries: Vec<(String, String)> = metadata.entries.into_iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(entries)
+}
+
+/// Delete a metadata key from a runtime.
+pub fn metadata_delete(id_prefix: &str, key: &str, config: &Config) -> Result<(), AvocadoError> {
+    let base_dir = config.get_avocado_base_dir();
+    let base_path = Path::new(&base_dir);
+    let runtimes = RuntimeManifest::list_all(base_path);
+    let matched = resolve_runtime(id_prefix, &runtimes)?;
+
+    let runtime_dir = base_path.join("runtimes").join(&matched.id);
+    let mut metadata = crate::metadata::RuntimeMetadata::load(&runtime_dir);
+    if metadata.entries.remove(key).is_none() {
+        return Err(AvocadoError::MetadataKeyNotFound {
+            id: matched.id.clone(),
+            key: key.to_string(),
+        });
+    }
+    metadata
+        .save(&runtime_dir)
+        .map_err(|e| AvocadoError::StagingFailed {
+            reason: format!("Failed to save metadata: {e}"),
+        })?;
+    Ok(())
+}
+
 /// Resolve a runtime ID prefix to a unique RuntimeManifest.
 fn resolve_runtime<'a>(
     id_prefix: &str,

--- a/src/varlink/org.avocado.Runtimes.varlink
+++ b/src/varlink/org.avocado.Runtimes.varlink
@@ -46,8 +46,26 @@ method Activate(id: string) -> (message: string, done: bool, runtime: ?Runtime)
 # Inspect a runtime's details (omit id to inspect the active runtime)
 method Inspect(id: ?string) -> (runtime: Runtime)
 
+type MetadataEntry (
+    key: string,
+    value: string
+)
+
+# Set a metadata key-value pair on a runtime
+method MetadataSet(id: string, key: string, value: string) -> ()
+
+# Get a metadata value by key
+method MetadataGet(id: string, key: string) -> (value: string)
+
+# List all metadata for a runtime
+method MetadataList(id: string) -> (entries: []MetadataEntry)
+
+# Delete a metadata key
+method MetadataDelete(id: string, key: string) -> ()
+
 error RuntimeNotFound (id: string)
 error AmbiguousRuntimeId (id: string, candidates: []string)
 error RemoveActiveRuntime ()
 error StagingFailed (reason: string)
 error UpdateFailed (reason: string)
+error MetadataKeyNotFound (id: string, key: string)

--- a/src/varlink/org.avocado.Runtimes.varlink
+++ b/src/varlink/org.avocado.Runtimes.varlink
@@ -63,6 +63,14 @@ method MetadataList(id: string) -> (entries: []MetadataEntry)
 # Delete a metadata key
 method MetadataDelete(id: string, key: string) -> ()
 
+type GcResult (
+    removedRuntimes: []string,
+    removedImages: []string
+)
+
+# Run garbage collection to remove old runtimes and unreferenced images
+method GarbageCollect() -> (result: GcResult)
+
 error RuntimeNotFound (id: string)
 error AmbiguousRuntimeId (id: string, candidates: []string)
 error RemoveActiveRuntime ()

--- a/src/varlink/org_avocado_Runtimes.rs
+++ b/src/varlink/org_avocado_Runtimes.rs
@@ -12,6 +12,7 @@ pub enum ErrorKind {
     Varlink_Error,
     VarlinkReply_Error,
     AmbiguousRuntimeId(Option<AmbiguousRuntimeId_Args>),
+    MetadataKeyNotFound(Option<MetadataKeyNotFound_Args>),
     RemoveActiveRuntime(Option<RemoveActiveRuntime_Args>),
     RuntimeNotFound(Option<RuntimeNotFound_Args>),
     StagingFailed(Option<StagingFailed_Args>),
@@ -24,6 +25,9 @@ impl ::std::fmt::Display for ErrorKind {
             ErrorKind::VarlinkReply_Error => write!(f, "Varlink error reply"),
             ErrorKind::AmbiguousRuntimeId(v) => {
                 write!(f, "org.avocado.Runtimes.AmbiguousRuntimeId: {:#?}", v)
+            }
+            ErrorKind::MetadataKeyNotFound(v) => {
+                write!(f, "org.avocado.Runtimes.MetadataKeyNotFound: {:#?}", v)
             }
             ErrorKind::RemoveActiveRuntime(v) => {
                 write!(f, "org.avocado.Runtimes.RemoveActiveRuntime: {:#?}", v)
@@ -135,6 +139,20 @@ impl From<&varlink::Reply> for ErrorKind {
                 }
             }
             varlink::Reply { error: Some(t), .. }
+                if t == "org.avocado.Runtimes.MetadataKeyNotFound" =>
+            {
+                match e {
+                    varlink::Reply {
+                        parameters: Some(p),
+                        ..
+                    } => match serde_json::from_value(p.clone()) {
+                        Ok(v) => ErrorKind::MetadataKeyNotFound(v),
+                        Err(_) => ErrorKind::MetadataKeyNotFound(None),
+                    },
+                    _ => ErrorKind::MetadataKeyNotFound(None),
+                }
+            }
+            varlink::Reply { error: Some(t), .. }
                 if t == "org.avocado.Runtimes.RemoveActiveRuntime" =>
             {
                 match e {
@@ -205,6 +223,15 @@ pub trait VarlinkCallError: varlink::CallTrait {
             ),
         ))
     }
+    fn reply_metadata_key_not_found(&mut self, r#id: String, r#key: String) -> varlink::Result<()> {
+        self.reply_struct(varlink::Reply::error(
+            "org.avocado.Runtimes.MetadataKeyNotFound",
+            Some(
+                serde_json::to_value(MetadataKeyNotFound_Args { r#id, r#key })
+                    .map_err(varlink::map_context!())?,
+            ),
+        ))
+    }
     fn reply_remove_active_runtime(&mut self) -> varlink::Result<()> {
         self.reply_struct(varlink::Reply::error(
             "org.avocado.Runtimes.RemoveActiveRuntime",
@@ -249,6 +276,11 @@ pub struct r#ManifestExtension {
     pub r#sha256: Option<String>,
 }
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct r#MetadataEntry {
+    pub r#key: String,
+    pub r#value: String,
+}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct r#Runtime {
     pub r#id: String,
     pub r#manifestVersion: i64,
@@ -268,6 +300,11 @@ pub struct r#RuntimeInfo {
 pub struct AmbiguousRuntimeId_Args {
     pub r#id: String,
     pub r#candidates: Vec<String>,
+}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct MetadataKeyNotFound_Args {
+    pub r#id: String,
+    pub r#key: String,
 }
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct RemoveActiveRuntime_Args {}
@@ -412,6 +449,70 @@ pub trait Call_List: VarlinkCallError {
 }
 impl Call_List for varlink::Call<'_> {}
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct MetadataDelete_Reply {}
+impl varlink::VarlinkReply for MetadataDelete_Reply {}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct MetadataDelete_Args {
+    pub r#id: String,
+    pub r#key: String,
+}
+#[allow(dead_code)]
+pub trait Call_MetadataDelete: VarlinkCallError {
+    fn reply(&mut self) -> varlink::Result<()> {
+        self.reply_struct(varlink::Reply::parameters(None))
+    }
+}
+impl Call_MetadataDelete for varlink::Call<'_> {}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct MetadataGet_Reply {
+    pub r#value: String,
+}
+impl varlink::VarlinkReply for MetadataGet_Reply {}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct MetadataGet_Args {
+    pub r#id: String,
+    pub r#key: String,
+}
+#[allow(dead_code)]
+pub trait Call_MetadataGet: VarlinkCallError {
+    fn reply(&mut self, r#value: String) -> varlink::Result<()> {
+        self.reply_struct(MetadataGet_Reply { r#value }.into())
+    }
+}
+impl Call_MetadataGet for varlink::Call<'_> {}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct MetadataList_Reply {
+    pub r#entries: Vec<MetadataEntry>,
+}
+impl varlink::VarlinkReply for MetadataList_Reply {}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct MetadataList_Args {
+    pub r#id: String,
+}
+#[allow(dead_code)]
+pub trait Call_MetadataList: VarlinkCallError {
+    fn reply(&mut self, r#entries: Vec<MetadataEntry>) -> varlink::Result<()> {
+        self.reply_struct(MetadataList_Reply { r#entries }.into())
+    }
+}
+impl Call_MetadataList for varlink::Call<'_> {}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct MetadataSet_Reply {}
+impl varlink::VarlinkReply for MetadataSet_Reply {}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct MetadataSet_Args {
+    pub r#id: String,
+    pub r#key: String,
+    pub r#value: String,
+}
+#[allow(dead_code)]
+pub trait Call_MetadataSet: VarlinkCallError {
+    fn reply(&mut self) -> varlink::Result<()> {
+        self.reply_struct(varlink::Reply::parameters(None))
+    }
+}
+impl Call_MetadataSet for varlink::Call<'_> {}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Remove_Reply {}
 impl varlink::VarlinkReply for Remove_Reply {}
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -442,6 +543,26 @@ pub trait VarlinkInterface {
     ) -> varlink::Result<()>;
     fn inspect(&self, call: &mut dyn Call_Inspect, r#id: Option<String>) -> varlink::Result<()>;
     fn list(&self, call: &mut dyn Call_List) -> varlink::Result<()>;
+    fn metadata_delete(
+        &self,
+        call: &mut dyn Call_MetadataDelete,
+        r#id: String,
+        r#key: String,
+    ) -> varlink::Result<()>;
+    fn metadata_get(
+        &self,
+        call: &mut dyn Call_MetadataGet,
+        r#id: String,
+        r#key: String,
+    ) -> varlink::Result<()>;
+    fn metadata_list(&self, call: &mut dyn Call_MetadataList, r#id: String) -> varlink::Result<()>;
+    fn metadata_set(
+        &self,
+        call: &mut dyn Call_MetadataSet,
+        r#id: String,
+        r#key: String,
+        r#value: String,
+    ) -> varlink::Result<()>;
     fn remove(&self, call: &mut dyn Call_Remove, r#id: String) -> varlink::Result<()>;
     fn call_upgraded(
         &self,
@@ -472,6 +593,26 @@ pub trait VarlinkClientInterface {
         r#id: Option<String>,
     ) -> varlink::MethodCall<Inspect_Args, Inspect_Reply, Error>;
     fn list(&mut self) -> varlink::MethodCall<List_Args, List_Reply, Error>;
+    fn metadata_delete(
+        &mut self,
+        r#id: String,
+        r#key: String,
+    ) -> varlink::MethodCall<MetadataDelete_Args, MetadataDelete_Reply, Error>;
+    fn metadata_get(
+        &mut self,
+        r#id: String,
+        r#key: String,
+    ) -> varlink::MethodCall<MetadataGet_Args, MetadataGet_Reply, Error>;
+    fn metadata_list(
+        &mut self,
+        r#id: String,
+    ) -> varlink::MethodCall<MetadataList_Args, MetadataList_Reply, Error>;
+    fn metadata_set(
+        &mut self,
+        r#id: String,
+        r#key: String,
+        r#value: String,
+    ) -> varlink::MethodCall<MetadataSet_Args, MetadataSet_Reply, Error>;
     fn remove(&mut self, r#id: String) -> varlink::MethodCall<Remove_Args, Remove_Reply, Error>;
 }
 #[allow(dead_code)]
@@ -538,6 +679,54 @@ impl VarlinkClientInterface for VarlinkClient {
             List_Args {},
         )
     }
+    fn metadata_delete(
+        &mut self,
+        r#id: String,
+        r#key: String,
+    ) -> varlink::MethodCall<MetadataDelete_Args, MetadataDelete_Reply, Error> {
+        varlink::MethodCall::<MetadataDelete_Args, MetadataDelete_Reply, Error>::new(
+            self.connection.clone(),
+            "org.avocado.Runtimes.MetadataDelete",
+            MetadataDelete_Args { r#id, r#key },
+        )
+    }
+    fn metadata_get(
+        &mut self,
+        r#id: String,
+        r#key: String,
+    ) -> varlink::MethodCall<MetadataGet_Args, MetadataGet_Reply, Error> {
+        varlink::MethodCall::<MetadataGet_Args, MetadataGet_Reply, Error>::new(
+            self.connection.clone(),
+            "org.avocado.Runtimes.MetadataGet",
+            MetadataGet_Args { r#id, r#key },
+        )
+    }
+    fn metadata_list(
+        &mut self,
+        r#id: String,
+    ) -> varlink::MethodCall<MetadataList_Args, MetadataList_Reply, Error> {
+        varlink::MethodCall::<MetadataList_Args, MetadataList_Reply, Error>::new(
+            self.connection.clone(),
+            "org.avocado.Runtimes.MetadataList",
+            MetadataList_Args { r#id },
+        )
+    }
+    fn metadata_set(
+        &mut self,
+        r#id: String,
+        r#key: String,
+        r#value: String,
+    ) -> varlink::MethodCall<MetadataSet_Args, MetadataSet_Reply, Error> {
+        varlink::MethodCall::<MetadataSet_Args, MetadataSet_Reply, Error>::new(
+            self.connection.clone(),
+            "org.avocado.Runtimes.MetadataSet",
+            MetadataSet_Args {
+                r#id,
+                r#key,
+                r#value,
+            },
+        )
+    }
     fn remove(&mut self, r#id: String) -> varlink::MethodCall<Remove_Args, Remove_Reply, Error> {
         varlink::MethodCall::<Remove_Args, Remove_Reply, Error>::new(
             self.connection.clone(),
@@ -556,7 +745,7 @@ pub fn new(inner: Box<dyn VarlinkInterface + Send + Sync>) -> VarlinkInterfacePr
 }
 impl varlink::Interface for VarlinkInterfaceProxy {
     fn get_description(&self) -> &'static str {
-        "# Runtime lifecycle management for Avocado Linux\ninterface org.avocado.Runtimes\n\ntype RuntimeInfo (\n    name: string,\n    version: string\n)\n\ntype ManifestExtension (\n    name: string,\n    version: string,\n    imageId: ?string,\n    imageType: ?string,\n    sha256: ?string\n)\n\ntype Runtime (\n    id: string,\n    manifestVersion: int,\n    builtAt: string,\n    runtime: RuntimeInfo,\n    extensions: []ManifestExtension,\n    active: bool,\n    osBuildId: ?string,\n    initramfsBuildId: ?string\n)\n\n# List all available runtimes\nmethod List() -> (runtimes: []Runtime)\n\n# Add a runtime from a TUF repository URL (authToken: optional bearer token for protected endpoints)\n# Supports streaming: client may set more=true to receive per-message progress\nmethod AddFromUrl(url: string, authToken: ?string, artifactsUrl: ?string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Add a runtime from a local manifest file\n# Supports streaming: client may set more=true to receive per-message progress\nmethod AddFromManifest(manifestPath: string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Remove a staged runtime by ID (or prefix)\nmethod Remove(id: string) -> ()\n\n# Activate a staged runtime by ID (or prefix)\n# Supports streaming: client may set more=true to receive per-message progress\nmethod Activate(id: string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Inspect a runtime's details (omit id to inspect the active runtime)\nmethod Inspect(id: ?string) -> (runtime: Runtime)\n\nerror RuntimeNotFound (id: string)\nerror AmbiguousRuntimeId (id: string, candidates: []string)\nerror RemoveActiveRuntime ()\nerror StagingFailed (reason: string)\nerror UpdateFailed (reason: string)\n"
+        "# Runtime lifecycle management for Avocado Linux\ninterface org.avocado.Runtimes\n\ntype RuntimeInfo (\n    name: string,\n    version: string\n)\n\ntype ManifestExtension (\n    name: string,\n    version: string,\n    imageId: ?string,\n    imageType: ?string,\n    sha256: ?string\n)\n\ntype Runtime (\n    id: string,\n    manifestVersion: int,\n    builtAt: string,\n    runtime: RuntimeInfo,\n    extensions: []ManifestExtension,\n    active: bool,\n    osBuildId: ?string,\n    initramfsBuildId: ?string\n)\n\n# List all available runtimes\nmethod List() -> (runtimes: []Runtime)\n\n# Add a runtime from a TUF repository URL (authToken: optional bearer token for protected endpoints)\n# Supports streaming: client may set more=true to receive per-message progress\nmethod AddFromUrl(url: string, authToken: ?string, artifactsUrl: ?string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Add a runtime from a local manifest file\n# Supports streaming: client may set more=true to receive per-message progress\nmethod AddFromManifest(manifestPath: string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Remove a staged runtime by ID (or prefix)\nmethod Remove(id: string) -> ()\n\n# Activate a staged runtime by ID (or prefix)\n# Supports streaming: client may set more=true to receive per-message progress\nmethod Activate(id: string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Inspect a runtime's details (omit id to inspect the active runtime)\nmethod Inspect(id: ?string) -> (runtime: Runtime)\n\ntype MetadataEntry (\n    key: string,\n    value: string\n)\n\n# Set a metadata key-value pair on a runtime\nmethod MetadataSet(id: string, key: string, value: string) -> ()\n\n# Get a metadata value by key\nmethod MetadataGet(id: string, key: string) -> (value: string)\n\n# List all metadata for a runtime\nmethod MetadataList(id: string) -> (entries: []MetadataEntry)\n\n# Delete a metadata key\nmethod MetadataDelete(id: string, key: string) -> ()\n\nerror RuntimeNotFound (id: string)\nerror AmbiguousRuntimeId (id: string, candidates: []string)\nerror RemoveActiveRuntime ()\nerror StagingFailed (reason: string)\nerror UpdateFailed (reason: string)\nerror MetadataKeyNotFound (id: string, key: string)\n"
     }
     fn get_name(&self) -> &'static str {
         "org.avocado.Runtimes"
@@ -641,6 +830,80 @@ impl varlink::Interface for VarlinkInterfaceProxy {
                 }
             }
             "org.avocado.Runtimes.List" => self.inner.list(call as &mut dyn Call_List),
+            "org.avocado.Runtimes.MetadataDelete" => {
+                if let Some(args) = req.parameters.clone() {
+                    let args: MetadataDelete_Args = match serde_json::from_value(args) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            let es = format!("{}", e);
+                            let _ = call.reply_invalid_parameter(es.clone());
+                            return Err(varlink::context!(varlink::ErrorKind::SerdeJsonDe(es)));
+                        }
+                    };
+                    self.inner.metadata_delete(
+                        call as &mut dyn Call_MetadataDelete,
+                        args.r#id,
+                        args.r#key,
+                    )
+                } else {
+                    call.reply_invalid_parameter("parameters".into())
+                }
+            }
+            "org.avocado.Runtimes.MetadataGet" => {
+                if let Some(args) = req.parameters.clone() {
+                    let args: MetadataGet_Args = match serde_json::from_value(args) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            let es = format!("{}", e);
+                            let _ = call.reply_invalid_parameter(es.clone());
+                            return Err(varlink::context!(varlink::ErrorKind::SerdeJsonDe(es)));
+                        }
+                    };
+                    self.inner.metadata_get(
+                        call as &mut dyn Call_MetadataGet,
+                        args.r#id,
+                        args.r#key,
+                    )
+                } else {
+                    call.reply_invalid_parameter("parameters".into())
+                }
+            }
+            "org.avocado.Runtimes.MetadataList" => {
+                if let Some(args) = req.parameters.clone() {
+                    let args: MetadataList_Args = match serde_json::from_value(args) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            let es = format!("{}", e);
+                            let _ = call.reply_invalid_parameter(es.clone());
+                            return Err(varlink::context!(varlink::ErrorKind::SerdeJsonDe(es)));
+                        }
+                    };
+                    self.inner
+                        .metadata_list(call as &mut dyn Call_MetadataList, args.r#id)
+                } else {
+                    call.reply_invalid_parameter("parameters".into())
+                }
+            }
+            "org.avocado.Runtimes.MetadataSet" => {
+                if let Some(args) = req.parameters.clone() {
+                    let args: MetadataSet_Args = match serde_json::from_value(args) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            let es = format!("{}", e);
+                            let _ = call.reply_invalid_parameter(es.clone());
+                            return Err(varlink::context!(varlink::ErrorKind::SerdeJsonDe(es)));
+                        }
+                    };
+                    self.inner.metadata_set(
+                        call as &mut dyn Call_MetadataSet,
+                        args.r#id,
+                        args.r#key,
+                        args.r#value,
+                    )
+                } else {
+                    call.reply_invalid_parameter("parameters".into())
+                }
+            }
             "org.avocado.Runtimes.Remove" => {
                 if let Some(args) = req.parameters.clone() {
                     let args: Remove_Args = match serde_json::from_value(args) {

--- a/src/varlink/org_avocado_Runtimes.rs
+++ b/src/varlink/org_avocado_Runtimes.rs
@@ -268,6 +268,11 @@ pub trait VarlinkCallError: varlink::CallTrait {
 }
 impl VarlinkCallError for varlink::Call<'_> {}
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct r#GcResult {
+    pub r#removedRuntimes: Vec<String>,
+    pub r#removedImages: Vec<String>,
+}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct r#ManifestExtension {
     pub r#name: String,
     pub r#version: String,
@@ -418,6 +423,20 @@ pub trait Call_AddFromUrl: VarlinkCallError {
 }
 impl Call_AddFromUrl for varlink::Call<'_> {}
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct GarbageCollect_Reply {
+    pub r#result: GcResult,
+}
+impl varlink::VarlinkReply for GarbageCollect_Reply {}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct GarbageCollect_Args {}
+#[allow(dead_code)]
+pub trait Call_GarbageCollect: VarlinkCallError {
+    fn reply(&mut self, r#result: GcResult) -> varlink::Result<()> {
+        self.reply_struct(GarbageCollect_Reply { r#result }.into())
+    }
+}
+impl Call_GarbageCollect for varlink::Call<'_> {}
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Inspect_Reply {
     pub r#runtime: Runtime,
 }
@@ -541,6 +560,7 @@ pub trait VarlinkInterface {
         r#authToken: Option<String>,
         r#artifactsUrl: Option<String>,
     ) -> varlink::Result<()>;
+    fn garbage_collect(&self, call: &mut dyn Call_GarbageCollect) -> varlink::Result<()>;
     fn inspect(&self, call: &mut dyn Call_Inspect, r#id: Option<String>) -> varlink::Result<()>;
     fn list(&self, call: &mut dyn Call_List) -> varlink::Result<()>;
     fn metadata_delete(
@@ -588,6 +608,9 @@ pub trait VarlinkClientInterface {
         r#authToken: Option<String>,
         r#artifactsUrl: Option<String>,
     ) -> varlink::MethodCall<AddFromUrl_Args, AddFromUrl_Reply, Error>;
+    fn garbage_collect(
+        &mut self,
+    ) -> varlink::MethodCall<GarbageCollect_Args, GarbageCollect_Reply, Error>;
     fn inspect(
         &mut self,
         r#id: Option<String>,
@@ -660,6 +683,15 @@ impl VarlinkClientInterface for VarlinkClient {
                 r#authToken,
                 r#artifactsUrl,
             },
+        )
+    }
+    fn garbage_collect(
+        &mut self,
+    ) -> varlink::MethodCall<GarbageCollect_Args, GarbageCollect_Reply, Error> {
+        varlink::MethodCall::<GarbageCollect_Args, GarbageCollect_Reply, Error>::new(
+            self.connection.clone(),
+            "org.avocado.Runtimes.GarbageCollect",
+            GarbageCollect_Args {},
         )
     }
     fn inspect(
@@ -745,7 +777,7 @@ pub fn new(inner: Box<dyn VarlinkInterface + Send + Sync>) -> VarlinkInterfacePr
 }
 impl varlink::Interface for VarlinkInterfaceProxy {
     fn get_description(&self) -> &'static str {
-        "# Runtime lifecycle management for Avocado Linux\ninterface org.avocado.Runtimes\n\ntype RuntimeInfo (\n    name: string,\n    version: string\n)\n\ntype ManifestExtension (\n    name: string,\n    version: string,\n    imageId: ?string,\n    imageType: ?string,\n    sha256: ?string\n)\n\ntype Runtime (\n    id: string,\n    manifestVersion: int,\n    builtAt: string,\n    runtime: RuntimeInfo,\n    extensions: []ManifestExtension,\n    active: bool,\n    osBuildId: ?string,\n    initramfsBuildId: ?string\n)\n\n# List all available runtimes\nmethod List() -> (runtimes: []Runtime)\n\n# Add a runtime from a TUF repository URL (authToken: optional bearer token for protected endpoints)\n# Supports streaming: client may set more=true to receive per-message progress\nmethod AddFromUrl(url: string, authToken: ?string, artifactsUrl: ?string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Add a runtime from a local manifest file\n# Supports streaming: client may set more=true to receive per-message progress\nmethod AddFromManifest(manifestPath: string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Remove a staged runtime by ID (or prefix)\nmethod Remove(id: string) -> ()\n\n# Activate a staged runtime by ID (or prefix)\n# Supports streaming: client may set more=true to receive per-message progress\nmethod Activate(id: string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Inspect a runtime's details (omit id to inspect the active runtime)\nmethod Inspect(id: ?string) -> (runtime: Runtime)\n\ntype MetadataEntry (\n    key: string,\n    value: string\n)\n\n# Set a metadata key-value pair on a runtime\nmethod MetadataSet(id: string, key: string, value: string) -> ()\n\n# Get a metadata value by key\nmethod MetadataGet(id: string, key: string) -> (value: string)\n\n# List all metadata for a runtime\nmethod MetadataList(id: string) -> (entries: []MetadataEntry)\n\n# Delete a metadata key\nmethod MetadataDelete(id: string, key: string) -> ()\n\nerror RuntimeNotFound (id: string)\nerror AmbiguousRuntimeId (id: string, candidates: []string)\nerror RemoveActiveRuntime ()\nerror StagingFailed (reason: string)\nerror UpdateFailed (reason: string)\nerror MetadataKeyNotFound (id: string, key: string)\n"
+        "# Runtime lifecycle management for Avocado Linux\ninterface org.avocado.Runtimes\n\ntype RuntimeInfo (\n    name: string,\n    version: string\n)\n\ntype ManifestExtension (\n    name: string,\n    version: string,\n    imageId: ?string,\n    imageType: ?string,\n    sha256: ?string\n)\n\ntype Runtime (\n    id: string,\n    manifestVersion: int,\n    builtAt: string,\n    runtime: RuntimeInfo,\n    extensions: []ManifestExtension,\n    active: bool,\n    osBuildId: ?string,\n    initramfsBuildId: ?string\n)\n\n# List all available runtimes\nmethod List() -> (runtimes: []Runtime)\n\n# Add a runtime from a TUF repository URL (authToken: optional bearer token for protected endpoints)\n# Supports streaming: client may set more=true to receive per-message progress\nmethod AddFromUrl(url: string, authToken: ?string, artifactsUrl: ?string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Add a runtime from a local manifest file\n# Supports streaming: client may set more=true to receive per-message progress\nmethod AddFromManifest(manifestPath: string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Remove a staged runtime by ID (or prefix)\nmethod Remove(id: string) -> ()\n\n# Activate a staged runtime by ID (or prefix)\n# Supports streaming: client may set more=true to receive per-message progress\nmethod Activate(id: string) -> (message: string, done: bool, runtime: ?Runtime)\n\n# Inspect a runtime's details (omit id to inspect the active runtime)\nmethod Inspect(id: ?string) -> (runtime: Runtime)\n\ntype MetadataEntry (\n    key: string,\n    value: string\n)\n\n# Set a metadata key-value pair on a runtime\nmethod MetadataSet(id: string, key: string, value: string) -> ()\n\n# Get a metadata value by key\nmethod MetadataGet(id: string, key: string) -> (value: string)\n\n# List all metadata for a runtime\nmethod MetadataList(id: string) -> (entries: []MetadataEntry)\n\n# Delete a metadata key\nmethod MetadataDelete(id: string, key: string) -> ()\n\ntype GcResult (\n    removedRuntimes: []string,\n    removedImages: []string\n)\n\n# Run garbage collection to remove old runtimes and unreferenced images\nmethod GarbageCollect() -> (result: GcResult)\n\nerror RuntimeNotFound (id: string)\nerror AmbiguousRuntimeId (id: string, candidates: []string)\nerror RemoveActiveRuntime ()\nerror StagingFailed (reason: string)\nerror UpdateFailed (reason: string)\nerror MetadataKeyNotFound (id: string, key: string)\n"
     }
     fn get_name(&self) -> &'static str {
         "org.avocado.Runtimes"
@@ -814,6 +846,9 @@ impl varlink::Interface for VarlinkInterfaceProxy {
                     call.reply_invalid_parameter("parameters".into())
                 }
             }
+            "org.avocado.Runtimes.GarbageCollect" => self
+                .inner
+                .garbage_collect(call as &mut dyn Call_GarbageCollect),
             "org.avocado.Runtimes.Inspect" => {
                 if let Some(args) = req.parameters.clone() {
                     let args: Inspect_Args = match serde_json::from_value(args) {

--- a/src/varlink_client.rs
+++ b/src/varlink_client.rs
@@ -279,6 +279,46 @@ pub fn print_runtime_detail(rt: &vl_rt::Runtime, output: &OutputManager) {
     println!();
 }
 
+// ── Metadata output helpers ──────────────────────────────────────────────────
+
+pub fn print_metadata_value(key: &str, value: &str, output: &OutputManager) {
+    if output.is_json() {
+        println!("{}", serde_json::json!({"key": key, "value": value}));
+    } else {
+        println!("{value}");
+    }
+}
+
+pub fn print_metadata_list(entries: &[vl_rt::MetadataEntry], output: &OutputManager) {
+    if output.is_json() {
+        match serde_json::to_string_pretty(entries) {
+            Ok(json) => println!("{json}"),
+            Err(e) => {
+                output.error("Output", &format!("JSON serialization failed: {e}"));
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
+    if entries.is_empty() {
+        println!("No metadata set for this runtime.");
+        return;
+    }
+
+    let key_width = entries
+        .iter()
+        .map(|e| e.key.len())
+        .max()
+        .unwrap_or(3)
+        .max(3);
+
+    println!("{:<kw$} VALUE", "KEY", kw = key_width);
+    for entry in entries {
+        println!("{:<kw$} {}", entry.key, entry.value, kw = key_width);
+    }
+}
+
 // ── Root authority output helper ──────────────────────────────────────────────
 
 pub fn print_root_authority(info: &Option<vl_ra::RootAuthorityInfo>, output: &OutputManager) {

--- a/src/varlink_server.rs
+++ b/src/varlink_server.rs
@@ -453,6 +453,16 @@ impl vl_rt::VarlinkInterface for RuntimesHandler {
             Err(e) => map_rt_error!(call, e),
         }
     }
+
+    fn garbage_collect(&self, call: &mut dyn vl_rt::Call_GarbageCollect) -> varlink::Result<()> {
+        match service::runtime::garbage_collect(&self.config) {
+            Ok(result) => call.reply(vl_rt::GcResult {
+                r#removedRuntimes: result.removed_runtimes,
+                r#removedImages: result.removed_images,
+            }),
+            Err(e) => map_rt_error!(call, e),
+        }
+    }
 }
 
 // ── HITL handler ────────────────────────────────────────────────────

--- a/src/varlink_server.rs
+++ b/src/varlink_server.rs
@@ -215,6 +215,9 @@ macro_rules! map_rt_error {
             AvocadoError::RemoveActiveRuntime => $call.reply_remove_active_runtime(),
             AvocadoError::StagingFailed { reason } => $call.reply_staging_failed(reason),
             AvocadoError::UpdateFailed { reason } => $call.reply_update_failed(reason),
+            AvocadoError::MetadataKeyNotFound { id, key } => {
+                $call.reply_metadata_key_not_found(id, key)
+            }
             e => $call.reply_staging_failed(e.to_string()),
         }
     }};
@@ -390,6 +393,63 @@ impl vl_rt::VarlinkInterface for RuntimesHandler {
     ) -> varlink::Result<()> {
         match service::runtime::inspect_runtime(id.as_deref(), &self.config) {
             Ok(entry) => call.reply(runtime_entry_to_varlink(entry)),
+            Err(e) => map_rt_error!(call, e),
+        }
+    }
+
+    fn metadata_set(
+        &self,
+        call: &mut dyn vl_rt::Call_MetadataSet,
+        r#id: String,
+        r#key: String,
+        r#value: String,
+    ) -> varlink::Result<()> {
+        match service::runtime::metadata_set(&id, &key, &value, &self.config) {
+            Ok(()) => call.reply(),
+            Err(e) => map_rt_error!(call, e),
+        }
+    }
+
+    fn metadata_get(
+        &self,
+        call: &mut dyn vl_rt::Call_MetadataGet,
+        r#id: String,
+        r#key: String,
+    ) -> varlink::Result<()> {
+        match service::runtime::metadata_get(&id, &key, &self.config) {
+            Ok(value) => call.reply(value),
+            Err(e) => map_rt_error!(call, e),
+        }
+    }
+
+    fn metadata_list(
+        &self,
+        call: &mut dyn vl_rt::Call_MetadataList,
+        r#id: String,
+    ) -> varlink::Result<()> {
+        match service::runtime::metadata_list(&id, &self.config) {
+            Ok(entries) => {
+                let vl_entries: Vec<vl_rt::MetadataEntry> = entries
+                    .into_iter()
+                    .map(|(k, v)| vl_rt::MetadataEntry {
+                        r#key: k,
+                        r#value: v,
+                    })
+                    .collect();
+                call.reply(vl_entries)
+            }
+            Err(e) => map_rt_error!(call, e),
+        }
+    }
+
+    fn metadata_delete(
+        &self,
+        call: &mut dyn vl_rt::Call_MetadataDelete,
+        r#id: String,
+        r#key: String,
+    ) -> varlink::Result<()> {
+        match service::runtime::metadata_delete(&id, &key, &self.config) {
+            Ok(()) => call.reply(),
             Err(e) => map_rt_error!(call, e),
         }
     }

--- a/tests/fixtures/example_config.toml
+++ b/tests/fixtures/example_config.toml
@@ -6,3 +6,9 @@
 # Directory where Avocado extensions are stored
 # Can be overridden by AVOCADO_EXTENSIONS_PATH environment variable
 dir = "/var/lib/avocado/images"
+
+# [avocado.gc]
+# Maximum number of runtimes to keep (including the active one).
+# The active runtime and any runtime referenced by a pending OS update are always kept.
+# Minimum: 1 (always keep the active runtime). Default: 3.
+# runtime_retention = 3

--- a/tests/fixtures/example_config.toml
+++ b/tests/fixtures/example_config.toml
@@ -12,3 +12,5 @@ dir = "/var/lib/avocado/images"
 # The active runtime and any runtime referenced by a pending OS update are always kept.
 # Minimum: 1 (always keep the active runtime). Default: 3.
 # runtime_retention = 3
+# Whether to automatically run GC after adding a runtime. Default: true.
+# auto_gc = true


### PR DESCRIPTION
## Summary
- Add runtime metadata key-value store (`avocadoctl runtime metadata set/get/list/delete`) with varlink RPC support
- Add runtime garbage collection (`avocadoctl runtime gc`) to remove old runtimes and unreferenced images
- Add `auto_gc` config option to enable automatic GC with configurable retention policy

## Test plan
- [ ] Verify `avocadoctl runtime metadata set/get/list/delete` commands work end-to-end
- [ ] Verify `avocadoctl runtime gc` removes old runtimes and unreferenced images
- [ ] Verify `auto_gc` config enables/disables automatic GC
- [ ] Verify varlink metadata and GC RPCs via varlink client
- [ ] Confirm no regressions in existing runtime commands (inspect, activate, unmerge)