### PR TITLE
ci: bump actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/security-reusable.yml
+++ b/.github/workflows/security-reusable.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -25,7 +25,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
## Summary

- Bump `actions/checkout@v4` → `@v5` and `actions/cache@v3` → `@v4` in CI workflows.
- GitHub Actions runners force Node 24 starting June 2, 2026; Node 20 is removed entirely on September 16, 2026. The v4 actions (and `actions/cache@v3`) run on Node 20 and emit deprecation annotations on every run.

## Test plan
- [ ] PR CI green