### PR TITLE
image_adaptor: stop serving a stale .raw after it is replaced

### DIFF
--- a/src/commands/ext.rs
+++ b/src/commands/ext.rs
@@ -2684,8 +2684,12 @@ fn analyze_image_extension(
             // this is not fatal - but it is reported unconditionally. Hiding it
             // behind --verbose is how a loop the kernel would not release went
             // unnoticed until it had accumulated on the board.
+            //
+            // Both adaptors retry the same teardown inside mount(), so one stuck
+            // loop legitimately produces two warnings. Each names its own stage
+            // so the pair does not read as the same complaint printed twice.
             if let Err(e) = adaptor.unmount(&mount_name, verbose) {
-                eprintln!("Warning: failed to unmount stale {mount_name}: {e}");
+                eprintln!("Warning: pre-remount cleanup could not unmount {mount_name}: {e}");
             }
             adaptor.mount(&mount_name, path, verbose)?
         } else {

--- a/src/commands/ext.rs
+++ b/src/commands/ext.rs
@@ -2515,7 +2515,14 @@ fn scan_extensions_from_all_sources_with_verbosity(
                 }
             }
 
-            cleanup_stale_mounts(&available_loop_names)?;
+            // Cleaning up loops for extensions we are *not* about to mount must
+            // never block mounting the ones we are: this scan backs `ext list`,
+            // `ext status` and `prepare_extension_environment`, so propagating a
+            // failure here (a single loop the kernel refuses to release, for an
+            // extension that no longer exists) would abort every one of them.
+            if let Err(e) = cleanup_stale_mounts(&available_loop_names) {
+                eprintln!("Warning: stale mount cleanup incomplete: {e}");
+            }
 
             for (ext_name, ext_version, path) in raw_files {
                 match extension_map.entry(ext_name.clone()) {

--- a/src/commands/ext.rs
+++ b/src/commands/ext.rs
@@ -1,6 +1,6 @@
 use crate::commands::image_adaptor::{
-    self, analyze_mounted_extension, extension_mount_point, unmount_all_persistent_mounts,
-    ImageAdaptor, ImageType, ImageTypeTag, KabAdaptor, RawAdaptor,
+    self, aggregate_failures, analyze_mounted_extension, extension_mount_point,
+    unmount_all_persistent_mounts, ImageAdaptor, ImageType, ImageTypeTag, KabAdaptor, RawAdaptor,
 };
 use crate::config::Config;
 use crate::output::OutputManager;
@@ -2673,10 +2673,12 @@ fn analyze_image_extension(
             if verbose {
                 println!("Backing file changed for {mount_name}, remounting...");
             }
+            // The remount below can still succeed after a partial teardown, so
+            // this is not fatal - but it is reported unconditionally. Hiding it
+            // behind --verbose is how a loop the kernel would not release went
+            // unnoticed until it had accumulated on the board.
             if let Err(e) = adaptor.unmount(&mount_name, verbose) {
-                if verbose {
-                    println!("Warning: failed to unmount stale {mount_name}: {e}");
-                }
+                eprintln!("Warning: failed to unmount stale {mount_name}: {e}");
             }
             adaptor.mount(&mount_name, path, verbose)?
         } else {
@@ -3043,6 +3045,12 @@ fn cleanup_stale_mounts(available_extensions: &[String]) -> Result<(), SystemdEr
         return Ok(());
     }
 
+    // Both halves of the cleanup always run and their failures are collected,
+    // so one loop the kernel refuses to release cannot abort the sweep and
+    // leave the remaining stale loops - raw and KAB alike - attached.
+    let mut attempted = 0;
+    let mut failures = Vec::new();
+
     // Clean up stale raw loop refs
     let loop_ref_dir = "/dev/disk/by-loop-ref";
     if Path::new(loop_ref_dir).exists() {
@@ -3056,7 +3064,11 @@ fn cleanup_stale_mounts(available_extensions: &[String]) -> Result<(), SystemdEr
             if let Some(loop_name) = entry.file_name().to_str() {
                 if !available_extensions.contains(&loop_name.to_string()) {
                     println!("Cleaning up stale raw loop for: {loop_name}");
-                    raw.unmount(loop_name, false)?;
+                    attempted += 1;
+                    if let Err(e) = raw.unmount(loop_name, false) {
+                        eprintln!("Warning: failed to clean up stale raw loop {loop_name}: {e}");
+                        failures.push(format!("{loop_name}: {e}"));
+                    }
                 }
             }
         }
@@ -3077,14 +3089,20 @@ fn cleanup_stale_mounts(available_extensions: &[String]) -> Result<(), SystemdEr
                 if let Some(loop_name) = entry.file_name().to_str() {
                     if !available_extensions.contains(&loop_name.to_string()) {
                         println!("Cleaning up stale KAB loop for: {loop_name}");
-                        let _ = kab.unmount(loop_name, false);
+                        attempted += 1;
+                        if let Err(e) = kab.unmount(loop_name, false) {
+                            eprintln!(
+                                "Warning: failed to clean up stale KAB loop {loop_name}: {e}"
+                            );
+                            failures.push(format!("{loop_name}: {e}"));
+                        }
                     }
                 }
             }
         }
     }
 
-    Ok(())
+    aggregate_failures(attempted, failures)
 }
 
 /// Clean up all extension symlinks to ensure fresh state for merge

--- a/src/commands/image_adaptor.rs
+++ b/src/commands/image_adaptor.rs
@@ -24,6 +24,35 @@ pub enum SystemdError {
 
     #[error("Configuration error: {message}")]
     ConfigurationError { message: String },
+
+    #[error("{failures} of {attempted} unmount operations failed: {details}")]
+    UnmountBatchFailed {
+        attempted: usize,
+        failures: usize,
+        details: String,
+    },
+}
+
+/// Fold the failures of a best-effort teardown batch into a single result.
+///
+/// A teardown loop must not stop at its first failure. One loop the kernel
+/// refuses to release would otherwise leave every later extension mounted, and
+/// where a caller runs several adaptors in sequence it would skip the remaining
+/// adaptors outright. Each entry is attempted, and what failed is reported once
+/// at the end.
+pub(crate) fn aggregate_failures(
+    attempted: usize,
+    failures: Vec<String>,
+) -> Result<(), SystemdError> {
+    if failures.is_empty() {
+        return Ok(());
+    }
+
+    Err(SystemdError::UnmountBatchFailed {
+        attempted,
+        failures: failures.len(),
+        details: failures.join("; "),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -259,7 +288,19 @@ fn unmount_with_dissect(mount_point: &str, verbose: bool) -> Result<(), SystemdE
 /// Check if a loop device's backing file differs from the expected path.
 /// `loop_dev` can be a symlink (e.g. `/dev/disk/by-loop-ref/name`) or a direct
 /// device path (`/dev/loopN`).
-fn check_backing_file_changed(loop_dev: &Path, expected_path: &Path) -> bool {
+///
+/// `exposed_bytes` is how large the loop should be while it is still serving
+/// the expected image, and the caller has to supply it because it is not always
+/// the backing file's length. A KAB loop is attached with
+/// `--offset`/`--sizelimit=layer.img`, so it is sized to the image inside the
+/// archive while `expected_path` is the whole `.kab`; measuring it against the
+/// archive never matches and reports a change on every call. Pass `None` when
+/// the size cannot be established - the path comparison still applies.
+fn check_backing_file_changed(
+    loop_dev: &Path,
+    expected_path: &Path,
+    exposed_bytes: Option<u64>,
+) -> bool {
     if is_test_mode() {
         return false;
     }
@@ -305,9 +346,14 @@ fn check_backing_file_changed(loop_dev: &Path, expected_path: &Path) -> bool {
     // that needs a fingerprint recorded at mount time, which is worth doing
     // separately rather than folding into this predicate.
     //
-    // Unreadable sysfs or metadata reports unchanged, matching how every other
-    // failure in this function behaves - the size check only ever adds
-    // detections, it never removes one.
+    // An unknown expected size, unreadable sysfs, or unreadable metadata
+    // reports unchanged, matching how every other failure in this function
+    // behaves - the size check only ever adds detections, it never removes one.
+    let exposed_bytes = match exposed_bytes {
+        Some(n) => n,
+        None => return false,
+    };
+
     let sysfs_size = format!("/sys/block/{dev_name}/size");
     let loop_sectors = match fs::read_to_string(&sysfs_size) {
         Ok(s) => match s.trim().parse::<u64>() {
@@ -317,22 +363,28 @@ fn check_backing_file_changed(loop_dev: &Path, expected_path: &Path) -> bool {
         Err(_) => return false,
     };
 
-    let file_bytes = match fs::metadata(expected_path) {
-        Ok(m) => m.len(),
-        Err(_) => return false,
-    };
-
-    !loop_size_matches(loop_sectors, file_bytes)
+    !loop_size_matches(loop_sectors, exposed_bytes)
 }
 
-/// Whether a loop device of `loop_sectors` is backed by a file of `file_bytes`.
+/// Bytes the loop for a raw image should be exposing: the whole file.
+fn raw_exposed_bytes(path: &Path) -> Option<u64> {
+    fs::metadata(path).ok().map(|m| m.len())
+}
+
+/// Whether a loop of `loop_sectors` is still exposing `exposed_bytes`.
 ///
 /// `/sys/block/<dev>/size` counts 512-byte sectors regardless of the device's
-/// logical block size. Split out from `check_backing_file_changed` so the
-/// arithmetic is testable without a loop device: everything around it is gated
-/// behind `is_test_mode()` and cannot run under `cargo test`.
-fn loop_size_matches(loop_sectors: u64, file_bytes: u64) -> bool {
-    loop_sectors.saturating_mul(512) == file_bytes
+/// logical block size, and the kernel derives that count by truncating the
+/// exposed length. The comparison has to truncate the same way: measuring
+/// `loop_sectors * 512` against a length that is not a whole number of sectors
+/// never matches, which would report a change on every call for any image the
+/// kernel had to round down.
+///
+/// Split out from `check_backing_file_changed` so the arithmetic is testable
+/// without a loop device: everything around it is gated behind `is_test_mode()`
+/// and cannot run under `cargo test`.
+fn loop_size_matches(loop_sectors: u64, exposed_bytes: u64) -> bool {
+    loop_sectors == exposed_bytes / 512
 }
 
 /// What mounting an extension should do, given what is already attached.
@@ -672,7 +724,7 @@ impl ImageAdaptor for RawAdaptor {
         let present = loop_ref.exists();
         let plan = plan_mount(
             present,
-            present && check_backing_file_changed(&loop_ref, raw_path),
+            present && check_backing_file_changed(&loop_ref, raw_path, raw_exposed_bytes(raw_path)),
         );
 
         match plan {
@@ -687,10 +739,16 @@ impl ImageAdaptor for RawAdaptor {
             }
             // The image behind the loop is not the one we were asked to mount,
             // so the loop is worthless: drop it and attach a fresh one. A loop
-            // may survive this - the detach is best-effort - but only an actual
-            // image change pays that cost, not every merge.
+            // may survive this - the detach really is best-effort, so the
+            // teardown must not be propagated. Failing here would abort the
+            // merge and leave the replacement image unmounted, which is worse
+            // than the stranded loop it was trying to avoid.
             MountPlan::Replace => {
-                self.unmount(mount_name, verbose)?;
+                if let Err(e) = self.unmount(mount_name, verbose) {
+                    eprintln!(
+                        "Warning: could not fully tear down {mount_name} before replacing it: {e}"
+                    );
+                }
                 mount_with_dissect(mount_name, raw_path, &mount_point, true, verbose)?;
             }
             MountPlan::Fresh => {
@@ -718,7 +776,17 @@ impl ImageAdaptor for RawAdaptor {
 
     fn unmount(&self, mount_name: &str, verbose: bool) -> Result<(), SystemdError> {
         let mount_point = extension_mount_point(mount_name);
-        unmount_with_dissect(&mount_point, verbose)?;
+
+        // `-U` against a mount point that is not mounted fails, and the replace
+        // path unmounts twice: once by the caller that noticed the stale image,
+        // once by mount() tearing the old loop down before attaching a new one.
+        // Making the dissect call conditional turns the second one into a no-op
+        // instead of an error that aborts the merge.
+        if is_mount_active(&mount_point) {
+            unmount_with_dissect(&mount_point, verbose)?;
+        } else if verbose {
+            println!("{mount_point} is not mounted; skipping systemd-dissect -U");
+        }
 
         // -U leaves the persistent loop attached; drop it too, or the next
         // mount sees a live loop-ref and skips itself.
@@ -741,14 +809,22 @@ impl ImageAdaptor for RawAdaptor {
             source: e,
         })?;
 
+        // Best-effort per entry, matching KabAdaptor::unmount_all: one loop the
+        // kernel will not release must not leave every later extension mounted.
+        let mut attempted = 0;
+        let mut failures = Vec::new();
         for entry in entries.flatten() {
             if let Some(loop_name) = entry.file_name().to_str() {
                 println!("Unmounting raw loop: {loop_name}");
-                self.unmount(loop_name, false)?;
+                attempted += 1;
+                if let Err(e) = self.unmount(loop_name, false) {
+                    eprintln!("Warning: failed to unmount raw loop {loop_name}: {e}");
+                    failures.push(format!("{loop_name}: {e}"));
+                }
             }
         }
 
-        Ok(())
+        aggregate_failures(attempted, failures)
     }
 
     fn needs_remount(&self, mount_name: &str, expected_path: &Path) -> bool {
@@ -756,7 +832,11 @@ impl ImageAdaptor for RawAdaptor {
             return false;
         }
         let loop_ref = format!("/dev/disk/by-loop-ref/{mount_name}");
-        check_backing_file_changed(Path::new(&loop_ref), expected_path)
+        check_backing_file_changed(
+            Path::new(&loop_ref),
+            expected_path,
+            raw_exposed_bytes(expected_path),
+        )
     }
 
     fn type_tag(&self) -> ImageTypeTag {
@@ -1104,28 +1184,37 @@ impl ImageAdaptor for KabAdaptor {
             source: e,
         })?;
 
+        // Best-effort per entry, but the failures are still reported: dropping
+        // them silently hid undetachable loops from every caller.
+        let mut attempted = 0;
+        let mut failures = Vec::new();
         for entry in entries.flatten() {
             if let Some(mount_name) = entry.file_name().to_str() {
                 println!("Unmounting KAB: {mount_name}");
-                // Best-effort: log errors but continue
+                attempted += 1;
                 if let Err(e) = self.unmount(mount_name, false) {
                     eprintln!("Warning: failed to unmount KAB {mount_name}: {e}");
+                    failures.push(format!("{mount_name}: {e}"));
                 }
             }
         }
 
-        Ok(())
+        aggregate_failures(attempted, failures)
     }
 
     fn needs_remount(&self, mount_name: &str, kab_path: &Path) -> bool {
         if is_test_mode() {
             return false;
         }
-        if let Some(loop_dev) = Self::read_loop_state(mount_name) {
-            check_backing_file_changed(&loop_dev, kab_path)
-        } else {
-            false
-        }
+        let loop_dev = match Self::read_loop_state(mount_name) {
+            Some(dev) => dev,
+            None => return false,
+        };
+
+        // The loop exposes layer.img, not the .kab backing it, so the archive's
+        // own length is the wrong yardstick - see check_backing_file_changed.
+        let exposed_bytes = Self::find_image_entry(kab_path).ok().map(|entry| entry.len);
+        check_backing_file_changed(&loop_dev, kab_path, exposed_bytes)
     }
 
     fn type_tag(&self) -> ImageTypeTag {
@@ -1139,8 +1228,18 @@ impl ImageAdaptor for KabAdaptor {
 
 pub fn unmount_all_persistent_mounts() -> Result<(), SystemdError> {
     println!("Unmounting all persistent mounts...");
-    RawAdaptor.unmount_all()?;
-    KabAdaptor.unmount_all()?;
+
+    // Both adaptors always run. Propagating the raw failure here meant a single
+    // undetachable raw loop left every KAB offset loop attached.
+    let mut failures = Vec::new();
+    if let Err(e) = RawAdaptor.unmount_all() {
+        failures.push(format!("raw: {e}"));
+    }
+    if let Err(e) = KabAdaptor.unmount_all() {
+        failures.push(format!("kab: {e}"));
+    }
+    aggregate_failures(2, failures)?;
+
     println!("All persistent mounts unmounted.");
     Ok(())
 }
@@ -1208,9 +1307,37 @@ mod tests {
 
     #[test]
     fn loop_size_does_not_panic_on_an_absurd_sector_count() {
-        // saturating_mul rather than *: a garbage or truncated sysfs read must
-        // report "changed" instead of overflowing in release builds.
+        // Dividing the byte count rather than multiplying the sector count: a
+        // garbage or truncated sysfs read must report "changed" instead of
+        // overflowing in release builds.
         assert!(!loop_size_matches(u64::MAX, 121126912));
+    }
+
+    /// A loop's sector count is its exposed length truncated to 512 bytes, so
+    /// an image that is not a whole number of sectors still matches the loop
+    /// serving it. Comparing `sectors * 512` against the length instead
+    /// reported such an image as changed on every single call.
+    #[test]
+    fn loop_size_matches_an_image_that_is_not_a_whole_number_of_sectors() {
+        assert!(loop_size_matches(8, 4097));
+    }
+
+    #[test]
+    fn a_batch_with_no_failures_succeeds() {
+        assert!(aggregate_failures(3, Vec::new()).is_ok());
+    }
+
+    /// A teardown loop that stops at its first failure leaves everything after
+    /// it mounted. Every entry is attempted and the failures are reported once.
+    #[test]
+    fn a_batch_reports_every_failure_not_just_the_first() {
+        let err = aggregate_failures(3, vec!["a: busy".to_string(), "b: busy".to_string()])
+            .expect_err("a batch that had failures must not report success");
+
+        assert_eq!(
+            err.to_string(),
+            "2 of 3 unmount operations failed: a: busy; b: busy"
+        );
     }
 
     #[test]

--- a/src/commands/image_adaptor.rs
+++ b/src/commands/image_adaptor.rs
@@ -757,11 +757,13 @@ impl ImageAdaptor for RawAdaptor {
             // may survive this - the detach really is best-effort, so the
             // teardown must not be propagated. Failing here would abort the
             // merge and leave the replacement image unmounted, which is worse
-            // than the stranded loop it was trying to avoid.
+            // than the stranded loop it was trying to avoid. A caller that
+            // unmounted first has already warned about this same loop, so the
+            // message names this stage rather than repeating the caller's.
             MountPlan::Replace => {
                 if let Err(e) = self.unmount(mount_name, verbose) {
                     eprintln!(
-                        "Warning: could not fully tear down {mount_name} before replacing it: {e}"
+                        "Warning: mount-time teardown retry could not release {mount_name}: {e}"
                     );
                 }
                 mount_with_dissect(mount_name, raw_path, &mount_point, true, verbose)?;
@@ -1146,11 +1148,13 @@ impl ImageAdaptor for KabAdaptor {
         // `cleanup_stale_mounts` only ever reads the name the state file
         // currently holds, never a loop it has already been overwritten away
         // from. Best-effort, like every other teardown in this file - the
-        // merge must proceed even if the old loop is stuck.
+        // merge must proceed even if the old loop is stuck. A caller that
+        // unmounted first has already warned about this same loop, so the
+        // message names this stage rather than repeating the caller's.
         if let Some(old_loop) = Self::read_loop_state(mount_name) {
             if let Err(e) = Self::detach_offset_loop(&old_loop) {
                 eprintln!(
-                    "Warning: could not detach stale offset loop {} for {mount_name} before replacing it: {e}",
+                    "Warning: mount-time teardown retry could not detach stale offset loop {} for {mount_name}: {e}",
                     old_loop.display()
                 );
             }

--- a/src/commands/image_adaptor.rs
+++ b/src/commands/image_adaptor.rs
@@ -335,6 +335,43 @@ fn loop_size_matches(loop_sectors: u64, file_bytes: u64) -> bool {
     loop_sectors.saturating_mul(512) == file_bytes
 }
 
+/// What mounting an extension should do, given what is already attached.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MountPlan {
+    /// Nothing is attached. Mount the file; systemd-dissect attaches a loop.
+    Fresh,
+    /// A loop is attached and still exposes this exact image. Mount that device
+    /// rather than the file, so no second loop is attached for the same content.
+    Reuse,
+    /// A loop is attached but exposes different content. Tear it down, then
+    /// mount the file.
+    Replace,
+}
+
+/// Decide how to mount, from the two facts the caller can observe.
+///
+/// This exists as a pure function because the rest of the mount path cannot be
+/// exercised under `cargo test` - `is_test_mode()` short-circuits the very
+/// `systemd-dissect` and `losetup` calls the behaviour depends on. That gap is
+/// how the previous version of this fix reached hardware with a wrong premise:
+/// 276 green tests said nothing about whether it worked.
+///
+/// `ReuseLoop` is the case that matters. `systemd-dissect -U` leaves the loop
+/// attached by design, and on an unmerge/merge cycle the kernel does not
+/// release it even after an explicit `losetup -d` - measured on an i.MX93
+/// board, where no open fd, no mount in any namespace, no overlay lowerdir and
+/// no block holder referenced the loop, and a cache drop did not free it.
+/// Mounting the file again therefore attaches a SECOND loop for identical
+/// content and strands the first: two per cycle, on a device that merges
+/// extensions on every update.
+pub(crate) fn plan_mount(loop_ref_present: bool, backing_changed: bool) -> MountPlan {
+    match (loop_ref_present, backing_changed) {
+        (false, _) => MountPlan::Fresh,
+        (true, false) => MountPlan::Reuse,
+        (true, true) => MountPlan::Replace,
+    }
+}
+
 /// Detach the persistent loop behind `mount_name`, if one is still attached.
 ///
 /// `systemd-dissect -U` unmounts the mount point but deliberately leaves a
@@ -631,7 +668,36 @@ impl ImageAdaptor for RawAdaptor {
             return Ok(PathBuf::from(mount_point));
         }
 
-        mount_with_dissect(mount_name, raw_path, &mount_point, true, verbose)?;
+        let loop_ref = PathBuf::from(format!("/dev/disk/by-loop-ref/{mount_name}"));
+        let present = loop_ref.exists();
+        let plan = plan_mount(
+            present,
+            present && check_backing_file_changed(&loop_ref, raw_path),
+        );
+
+        match plan {
+            // Mount the loop we already have. Mounting the file instead would
+            // attach a second loop for the same image and leak the first, since
+            // the unmount left it attached and the kernel will not release it.
+            MountPlan::Reuse => {
+                if verbose {
+                    println!("Reusing attached loop for {mount_name}");
+                }
+                mount_with_dissect(mount_name, &loop_ref, &mount_point, false, verbose)?;
+            }
+            // The image behind the loop is not the one we were asked to mount,
+            // so the loop is worthless: drop it and attach a fresh one. A loop
+            // may survive this - the detach is best-effort - but only an actual
+            // image change pays that cost, not every merge.
+            MountPlan::Replace => {
+                self.unmount(mount_name, verbose)?;
+                mount_with_dissect(mount_name, raw_path, &mount_point, true, verbose)?;
+            }
+            MountPlan::Fresh => {
+                mount_with_dissect(mount_name, raw_path, &mount_point, true, verbose)?;
+            }
+        }
+
         Ok(PathBuf::from(mount_point))
     }
 
@@ -1107,6 +1173,37 @@ mod tests {
     #[test]
     fn loop_size_treats_a_smaller_replacement_as_changed() {
         assert!(!loop_size_matches(236576, 4096));
+    }
+
+    /// An unmerge/merge cycle on an unchanged image must not attach a loop.
+    ///
+    /// This is the whole point of the change. `unmerge --unmount` leaves the
+    /// loop attached - measured, and not fixable from here - so the merge that
+    /// follows sees `loop_ref_present` with unchanged backing. Planning a fresh
+    /// loop there is what stranded two loops per cycle on hardware.
+    #[test]
+    fn an_unchanged_image_behind_an_attached_loop_reuses_it() {
+        assert_eq!(plan_mount(true, false), MountPlan::Reuse);
+    }
+
+    /// A genuinely replaced image cannot reuse the loop: it exposes the old
+    /// content, which is the staleness this whole area exists to prevent.
+    #[test]
+    fn a_replaced_image_behind_an_attached_loop_replaces_it() {
+        assert_eq!(plan_mount(true, true), MountPlan::Replace);
+    }
+
+    /// First mount after a boot, and the only case that legitimately attaches.
+    #[test]
+    fn nothing_attached_mounts_the_file() {
+        assert_eq!(plan_mount(false, false), MountPlan::Fresh);
+    }
+
+    /// With no loop attached there is nothing to compare against, so a stale
+    /// "changed" reading must not divert into a teardown of something absent.
+    #[test]
+    fn nothing_attached_mounts_the_file_even_if_change_is_reported() {
+        assert_eq!(plan_mount(false, true), MountPlan::Fresh);
     }
 
     #[test]

--- a/src/commands/image_adaptor.rs
+++ b/src/commands/image_adaptor.rs
@@ -288,7 +288,101 @@ fn check_backing_file_changed(loop_dev: &Path, expected_path: &Path) -> bool {
         .canonicalize()
         .unwrap_or_else(|_| PathBuf::from(&backing_file));
 
-    expected != current
+    if expected != current {
+        return true;
+    }
+
+    // Same path is not the same image. Replacing an extension in place - a
+    // plain `>` redirect, scp, or anything that truncates and rewrites - keeps
+    // both the path and the inode, so the comparison above sees no change while
+    // the loop still exposes the image it was attached to. That is how an
+    // extension update comes out reporting success and serving the previous
+    // contents.
+    //
+    // The loop's size is fixed when it is attached, so comparing it against the
+    // file on disk catches a replacement of a different size without needing to
+    // hash anything. A same-size replacement still slips through; detecting
+    // that needs a fingerprint recorded at mount time, which is worth doing
+    // separately rather than folding into this predicate.
+    //
+    // Unreadable sysfs or metadata reports unchanged, matching how every other
+    // failure in this function behaves - the size check only ever adds
+    // detections, it never removes one.
+    let sysfs_size = format!("/sys/block/{dev_name}/size");
+    let loop_sectors = match fs::read_to_string(&sysfs_size) {
+        Ok(s) => match s.trim().parse::<u64>() {
+            Ok(n) => n,
+            Err(_) => return false,
+        },
+        Err(_) => return false,
+    };
+
+    let file_bytes = match fs::metadata(expected_path) {
+        Ok(m) => m.len(),
+        Err(_) => return false,
+    };
+
+    !loop_size_matches(loop_sectors, file_bytes)
+}
+
+/// Whether a loop device of `loop_sectors` is backed by a file of `file_bytes`.
+///
+/// `/sys/block/<dev>/size` counts 512-byte sectors regardless of the device's
+/// logical block size. Split out from `check_backing_file_changed` so the
+/// arithmetic is testable without a loop device: everything around it is gated
+/// behind `is_test_mode()` and cannot run under `cargo test`.
+fn loop_size_matches(loop_sectors: u64, file_bytes: u64) -> bool {
+    loop_sectors.saturating_mul(512) == file_bytes
+}
+
+/// Detach the persistent loop behind `mount_name`, if one is still attached.
+///
+/// `systemd-dissect -U` unmounts the mount point but deliberately leaves a
+/// `--loop-ref` loop attached - that is what makes it persistent. Every caller
+/// of `unmount` wants the extension gone, either to tear it down outright or to
+/// replace it with a remount, so a loop that outlives the unmount is never what
+/// was asked for: it keeps the old image open, and `/dev/disk/by-loop-ref/<name>`
+/// keeps pointing at it, so the next mount is skipped as already-mounted.
+///
+/// Absent loop-ref is success, not failure - it means nothing is attached.
+fn detach_loop_ref(mount_name: &str, verbose: bool) -> Result<(), SystemdError> {
+    if is_test_mode() {
+        return Ok(());
+    }
+
+    let loop_ref = PathBuf::from(format!("/dev/disk/by-loop-ref/{mount_name}"));
+
+    // canonicalize resolves the ../../loopN symlink and tells us in one step
+    // whether anything is still there.
+    let dev = match fs::canonicalize(&loop_ref) {
+        Ok(d) => d,
+        Err(_) => return Ok(()),
+    };
+
+    let output = ProcessCommand::new("losetup")
+        .args(["-d", dev.to_str().unwrap_or("")])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| SystemdError::CommandFailed {
+            command: "losetup -d".to_string(),
+            source: e,
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(SystemdError::CommandExitedWithError {
+            command: "losetup -d".to_string(),
+            exit_code: output.status.code(),
+            stderr: stderr.to_string(),
+        });
+    }
+
+    if verbose {
+        println!("Detached {} for {mount_name}", dev.display());
+    }
+
+    Ok(())
 }
 
 /// Check if a mount point is currently active by scanning /proc/mounts.
@@ -542,13 +636,27 @@ impl ImageAdaptor for RawAdaptor {
     }
 
     fn is_mounted(&self, mount_name: &str) -> bool {
+        // The loop-ref symlink alone is not enough. systemd-dissect -U unmounts
+        // the mount point but leaves a --loop-ref loop attached, which is what
+        // "persistent" means, so the symlink outlives the mount. Reporting
+        // mounted on the strength of the symlink makes the caller skip the
+        // remount and present an extension whose contents are not there:
+        // observed as docker.service vanishing after an unmerge/merge cycle
+        // while `avocadoctl ext status` still said merged.
+        //
+        // KabAdaptor already pairs its loop check with is_mount_active for the
+        // same reason.
         let loop_ref_path = format!("/dev/disk/by-loop-ref/{mount_name}");
-        Path::new(&loop_ref_path).exists()
+        Path::new(&loop_ref_path).exists() && is_mount_active(&extension_mount_point(mount_name))
     }
 
     fn unmount(&self, mount_name: &str, verbose: bool) -> Result<(), SystemdError> {
         let mount_point = extension_mount_point(mount_name);
         unmount_with_dissect(&mount_point, verbose)?;
+
+        // -U leaves the persistent loop attached; drop it too, or the next
+        // mount sees a live loop-ref and skips itself.
+        detach_loop_ref(mount_name, verbose)?;
 
         if verbose {
             println!("Unmounted loop for {mount_name}");
@@ -979,6 +1087,34 @@ pub fn unmount_all_persistent_mounts() -> Result<(), SystemdError> {
 mod tests {
     use super::*;
     use crate::commands::test_env::ENV_VAR_MUTEX;
+
+    #[test]
+    fn loop_size_matches_an_exactly_sized_image() {
+        // 121126912 bytes is the docker extension that exposed this: an
+        // in-place replacement kept the path, so only the size distinguished
+        // the new image from the loop's.
+        assert!(loop_size_matches(236576, 121126912));
+    }
+
+    #[test]
+    fn loop_size_detects_an_image_replaced_with_a_different_size() {
+        // The replacement was 121131008 bytes against a loop still sized for
+        // the previous 121126912. Before this check the two were
+        // indistinguishable and the stale image stayed merged.
+        assert!(!loop_size_matches(236576, 121131008));
+    }
+
+    #[test]
+    fn loop_size_treats_a_smaller_replacement_as_changed() {
+        assert!(!loop_size_matches(236576, 4096));
+    }
+
+    #[test]
+    fn loop_size_does_not_panic_on_an_absurd_sector_count() {
+        // saturating_mul rather than *: a garbage or truncated sysfs read must
+        // report "changed" instead of overflowing in release builds.
+        assert!(!loop_size_matches(u64::MAX, 121126912));
+    }
 
     #[test]
     fn test_image_type_from_manifest() {

--- a/src/commands/image_adaptor.rs
+++ b/src/commands/image_adaptor.rs
@@ -424,6 +424,20 @@ pub(crate) fn plan_mount(loop_ref_present: bool, backing_changed: bool) -> Mount
     }
 }
 
+/// Render a device path as UTF-8 for a `losetup` argument, or a
+/// `ConfigurationError` naming what could not be represented.
+///
+/// `unwrap_or("")` here would silently pass an empty argument to
+/// `losetup -d`, which fails and reports as though the kernel had refused to
+/// release the loop - the exact signal every other error in this file keys
+/// off, so misreporting it this way is confusing rather than merely wrong.
+fn require_utf8_path(path: &Path) -> Result<&str, SystemdError> {
+    path.to_str()
+        .ok_or_else(|| SystemdError::ConfigurationError {
+            message: format!("device path is not valid UTF-8: {}", path.display()),
+        })
+}
+
 /// Detach the persistent loop behind `mount_name`, if one is still attached.
 ///
 /// `systemd-dissect -U` unmounts the mount point but deliberately leaves a
@@ -448,8 +462,9 @@ fn detach_loop_ref(mount_name: &str, verbose: bool) -> Result<(), SystemdError> 
         Err(_) => return Ok(()),
     };
 
+    let dev_str = require_utf8_path(&dev)?;
     let output = ProcessCommand::new("losetup")
-        .args(["-d", dev.to_str().unwrap_or("")])
+        .args(["-d", dev_str])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -1123,6 +1138,24 @@ impl ImageAdaptor for KabAdaptor {
             return Ok(PathBuf::from(mount_point));
         }
 
+        // A prior unmount may have left the state file pointing at an offset
+        // loop that failed to detach - the same undetachable-loop condition
+        // `plan_mount`'s docs describe for the raw adaptor. `save_loop_state`
+        // below overwrites that entry unconditionally, so without this the old
+        // loop would have no record anywhere once the new one is saved:
+        // `cleanup_stale_mounts` only ever reads the name the state file
+        // currently holds, never a loop it has already been overwritten away
+        // from. Best-effort, like every other teardown in this file - the
+        // merge must proceed even if the old loop is stuck.
+        if let Some(old_loop) = Self::read_loop_state(mount_name) {
+            if let Err(e) = Self::detach_offset_loop(&old_loop) {
+                eprintln!(
+                    "Warning: could not detach stale offset loop {} for {mount_name} before replacing it: {e}",
+                    old_loop.display()
+                );
+            }
+        }
+
         let loop_dev = Self::setup_offset_loop(kab_path, &entry)?;
         Self::save_loop_state(mount_name, &loop_dev)?;
 
@@ -1158,8 +1191,18 @@ impl ImageAdaptor for KabAdaptor {
             return Ok(());
         }
 
-        // Phase 1: systemd-dissect unmount
-        unmount_with_dissect(&mount_point, verbose)?;
+        // Phase 1: systemd-dissect unmount. `-U` against a mount point that is
+        // not mounted fails, which would abort here and skip Phase 2 below -
+        // stranding the offset loop and its state file exactly like the raw
+        // adaptor did before the same guard was added there. A stale KAB entry
+        // (the case `cleanup_stale_mounts` calls this for) is by definition one
+        // whose extension is gone, so its mount point is usually already
+        // unmounted.
+        if is_mount_active(&mount_point) {
+            unmount_with_dissect(&mount_point, verbose)?;
+        } else if verbose {
+            println!("{mount_point} is not mounted; skipping systemd-dissect -U");
+        }
 
         // Phase 2: Detach outer offset loop
         if let Some(loop_dev) = Self::read_loop_state(mount_name) {
@@ -1226,19 +1269,70 @@ impl ImageAdaptor for KabAdaptor {
 // Convenience: unmount all persistent mounts across all adaptor types
 // ---------------------------------------------------------------------------
 
+/// Fold multiple named `unmount_all` outcomes into one combined result.
+///
+/// Passing the adaptor count as `attempted` here previously produced a
+/// self-contradicting message: the outer number counted adaptors (2) while
+/// each adaptor's own `details` string already read "N of M unmount
+/// operations failed" counting individual loops, nesting one batch summary
+/// inside another. Reading the real `attempted`/`failures` counts back out of
+/// each `UnmountBatchFailed` and summing them gives one honest total instead.
+///
+/// Pure and independent of `is_test_mode()` - unlike the adaptors' own
+/// `unmount_all`, which only reach a real device path outside tests - so this
+/// is the one part of the aggregation that `cargo test` can actually exercise.
+pub(crate) fn combine_unmount_all_results(
+    results: Vec<(&str, Result<(), SystemdError>)>,
+) -> Result<(), SystemdError> {
+    let mut attempted = 0;
+    let mut failures = 0;
+    let mut details = Vec::new();
+
+    for (label, result) in results {
+        match result {
+            Ok(()) => {}
+            // A nested `UnmountBatchFailed`'s own `details` already concatenates
+            // several individual failures, so it must not be folded into
+            // `aggregate_failures` as a single Vec entry - that would count a
+            // three-loop failure as one. Read the real counts back out and sum
+            // them instead.
+            Err(SystemdError::UnmountBatchFailed {
+                attempted: a,
+                failures: f,
+                details: d,
+            }) => {
+                attempted += a;
+                failures += f;
+                details.push(format!("{label}: {d}"));
+            }
+            Err(e) => {
+                attempted += 1;
+                failures += 1;
+                details.push(format!("{label}: {e}"));
+            }
+        }
+    }
+
+    if failures == 0 {
+        return Ok(());
+    }
+
+    Err(SystemdError::UnmountBatchFailed {
+        attempted,
+        failures,
+        details: details.join("; "),
+    })
+}
+
 pub fn unmount_all_persistent_mounts() -> Result<(), SystemdError> {
     println!("Unmounting all persistent mounts...");
 
     // Both adaptors always run. Propagating the raw failure here meant a single
     // undetachable raw loop left every KAB offset loop attached.
-    let mut failures = Vec::new();
-    if let Err(e) = RawAdaptor.unmount_all() {
-        failures.push(format!("raw: {e}"));
-    }
-    if let Err(e) = KabAdaptor.unmount_all() {
-        failures.push(format!("kab: {e}"));
-    }
-    aggregate_failures(2, failures)?;
+    combine_unmount_all_results(vec![
+        ("raw", RawAdaptor.unmount_all()),
+        ("kab", KabAdaptor.unmount_all()),
+    ])?;
 
     println!("All persistent mounts unmounted.");
     Ok(())
@@ -1337,6 +1431,77 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "2 of 3 unmount operations failed: a: busy; b: busy"
+        );
+    }
+
+    /// `losetup -d ""` (an empty argument) reports as though the kernel had
+    /// refused to release the loop, which is indistinguishable from the real
+    /// failure mode this whole file exists to handle. A non-UTF-8 path must
+    /// surface as its own distinct error instead of silently degrading to that
+    /// empty argument via `unwrap_or("")`.
+    #[test]
+    fn non_utf8_device_path_is_a_configuration_error_not_an_empty_losetup_arg() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        // 0x80 alone is not a valid UTF-8 lead or continuation byte.
+        let bad_bytes = [b'/', b'd', b'e', b'v', b'/', 0x80, b'x'];
+        let path = Path::new(OsStr::from_bytes(&bad_bytes));
+
+        let err = require_utf8_path(path)
+            .expect_err("a non-UTF-8 path must not silently become an empty losetup argument");
+        assert!(matches!(err, SystemdError::ConfigurationError { .. }));
+    }
+
+    #[test]
+    fn combining_unmount_all_results_sums_attempted_honestly_across_adaptors() {
+        // Regression for a self-contradicting count: the caller previously
+        // passed `aggregate_failures(2, ...)` meaning "2 adaptors", while the
+        // nested `details` string already read "N of M unmount operations
+        // failed" meaning individual operations - producing output like
+        // "1 of 2 unmount operations failed: raw: 3 of 5 unmount operations
+        // failed: ...". The combined total must read as one honest count.
+        let raw_err = SystemdError::UnmountBatchFailed {
+            attempted: 5,
+            failures: 3,
+            details: "docker: busy; connect: busy; wifi: busy".to_string(),
+        };
+
+        let result = combine_unmount_all_results(vec![("raw", Err(raw_err)), ("kab", Ok(()))]);
+
+        let err = result.expect_err("a batch with a failing adaptor must not report success");
+        assert_eq!(
+            err.to_string(),
+            "3 of 5 unmount operations failed: raw: docker: busy; connect: busy; wifi: busy"
+        );
+    }
+
+    #[test]
+    fn combining_unmount_all_results_with_no_failures_succeeds() {
+        let result = combine_unmount_all_results(vec![("raw", Ok(())), ("kab", Ok(()))]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn combining_unmount_all_results_reports_both_adaptors_honestly() {
+        let raw_err = SystemdError::UnmountBatchFailed {
+            attempted: 2,
+            failures: 1,
+            details: "docker: busy".to_string(),
+        };
+        let kab_err = SystemdError::UnmountBatchFailed {
+            attempted: 1,
+            failures: 1,
+            details: "app: busy".to_string(),
+        };
+
+        let result =
+            combine_unmount_all_results(vec![("raw", Err(raw_err)), ("kab", Err(kab_err))]);
+
+        let err = result.expect_err("both adaptors failing must not report success");
+        assert_eq!(
+            err.to_string(),
+            "2 of 3 unmount operations failed: raw: docker: busy; kab: app: busy"
         );
     }
 

--- a/src/commands/image_adaptor.rs
+++ b/src/commands/image_adaptor.rs
@@ -438,6 +438,29 @@ fn require_utf8_path(path: &Path) -> Result<&str, SystemdError> {
         })
 }
 
+/// Resolve `loop_ref` to a loop device that is still attached, or None.
+///
+/// The by-loop-ref symlink is udev state and lags the kernel: `losetup -d`
+/// detaches the loop immediately, but the symlink survives until udev
+/// processes the change event. In that window the symlink still resolves -
+/// to a device with no backing file - so the symlink existing says nothing
+/// about a loop being attached. Treating it as attached makes the remount
+/// path hand systemd-dissect the dead device it just detached, and the
+/// remount fails. Attachment is what `/sys/block/<dev>/loop` existing
+/// means, so probe that instead.
+///
+/// `sysfs_block` is `/sys/block`, parameterized so the probe is testable
+/// without a real loop device.
+fn live_loop_device(loop_ref: &Path, sysfs_block: &Path) -> Option<PathBuf> {
+    let dev = fs::canonicalize(loop_ref).ok()?;
+    let name = dev.file_name()?;
+    if sysfs_block.join(name).join("loop/backing_file").exists() {
+        Some(dev)
+    } else {
+        None
+    }
+}
+
 /// Detach the persistent loop behind `mount_name`, if one is still attached.
 ///
 /// `systemd-dissect -U` unmounts the mount point but deliberately leaves a
@@ -455,11 +478,13 @@ fn detach_loop_ref(mount_name: &str, verbose: bool) -> Result<(), SystemdError> 
 
     let loop_ref = PathBuf::from(format!("/dev/disk/by-loop-ref/{mount_name}"));
 
-    // canonicalize resolves the ../../loopN symlink and tells us in one step
-    // whether anything is still there.
-    let dev = match fs::canonicalize(&loop_ref) {
-        Ok(d) => d,
-        Err(_) => return Ok(()),
+    // A dangling symlink and a symlink to an already-detached device are both
+    // "nothing attached": `losetup -d` on the latter would error and misreport
+    // an unmount that already did its job. The replace path unmounts twice, so
+    // the second detach must be a genuine no-op.
+    let dev = match live_loop_device(&loop_ref, Path::new("/sys/block")) {
+        Some(d) => d,
+        None => return Ok(()),
     };
 
     let dev_str = require_utf8_path(&dev)?;
@@ -736,7 +761,13 @@ impl ImageAdaptor for RawAdaptor {
         }
 
         let loop_ref = PathBuf::from(format!("/dev/disk/by-loop-ref/{mount_name}"));
-        let present = loop_ref.exists();
+        // The symlink existing is not enough: the remount path detaches with
+        // `losetup -d` and mounts again immediately, and udev removes the
+        // symlink asynchronously. In that window `exists()` is true while the
+        // device is dead, the backing-file check can read nothing and reports
+        // unchanged, and the plan comes out Reuse - handing systemd-dissect
+        // the very device the caller just detached. Probe actual attachment.
+        let present = live_loop_device(&loop_ref, Path::new("/sys/block")).is_some();
         let plan = plan_mount(
             present,
             present && check_backing_file_changed(&loop_ref, raw_path, raw_exposed_bytes(raw_path)),
@@ -1418,6 +1449,52 @@ mod tests {
     #[test]
     fn loop_size_matches_an_image_that_is_not_a_whole_number_of_sectors() {
         assert!(loop_size_matches(8, 4097));
+    }
+
+    /// The udev-lag window that made the remount fail: `losetup -d` has
+    /// detached the loop, the by-loop-ref symlink still resolves to the
+    /// device node, but /sys/block/<dev>/loop is gone. Counting that as
+    /// present planned a Reuse of a dead device.
+    #[test]
+    fn a_symlink_to_a_detached_loop_is_not_a_live_loop() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dev = tmp.path().join("loop7");
+        fs::write(&dev, b"").unwrap();
+        let link = tmp.path().join("by-loop-ref-name");
+        symlink(&dev, &link).unwrap();
+        let sysfs = tmp.path().join("sys-block");
+        fs::create_dir_all(sysfs.join("loop7")).unwrap(); // no loop/backing_file
+
+        assert_eq!(live_loop_device(&link, &sysfs), None);
+    }
+
+    #[test]
+    fn a_dangling_loop_ref_symlink_is_not_a_live_loop() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let link = tmp.path().join("by-loop-ref-name");
+        symlink(tmp.path().join("loop7-gone"), &link).unwrap();
+
+        assert_eq!(live_loop_device(&link, tmp.path()), None);
+    }
+
+    #[test]
+    fn an_attached_loop_resolves_to_its_device() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dev = tmp.path().join("loop7");
+        fs::write(&dev, b"").unwrap();
+        let link = tmp.path().join("by-loop-ref-name");
+        symlink(&dev, &link).unwrap();
+        let sysfs = tmp.path().join("sys-block");
+        fs::create_dir_all(sysfs.join("loop7/loop")).unwrap();
+        fs::write(sysfs.join("loop7/loop/backing_file"), "/data/ext.raw\n").unwrap();
+
+        assert_eq!(
+            live_loop_device(&link, &sysfs),
+            Some(dev.canonicalize().unwrap())
+        );
     }
 
     #[test]

--- a/src/os_update.rs
+++ b/src/os_update.rs
@@ -522,8 +522,10 @@ fn read_loader_device_part_uuid() -> Result<String, OsUpdateError> {
     // Skip the first 4 bytes (EFI variable attributes), rest is UTF-16LE
     let utf16_bytes = &raw[4..];
     let utf16: Vec<u16> = utf16_bytes
-        .chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|&chunk| u16::from_le_bytes(chunk))
         .collect();
 
     let uuid_str = String::from_utf16(&utf16)

--- a/src/service/error.rs
+++ b/src/service/error.rs
@@ -82,6 +82,14 @@ impl From<crate::commands::ext::SystemdError> for AvocadoError {
             crate::commands::ext::SystemdError::ConfigurationError { message } => {
                 AvocadoError::ConfigurationError { message }
             }
+            crate::commands::ext::SystemdError::UnmountBatchFailed {
+                attempted,
+                failures,
+                details,
+            } => AvocadoError::UnmountFailed {
+                extension: format!("{failures} of {attempted}"),
+                reason: details,
+            },
         }
     }
 }

--- a/src/service/error.rs
+++ b/src/service/error.rs
@@ -50,6 +50,13 @@ pub enum AvocadoError {
     #[error("Unmount failed for '{extension}': {reason}")]
     UnmountFailed { extension: String, reason: String },
 
+    #[error("{failures} of {attempted} unmount operations failed: {details}")]
+    UnmountBatchFailed {
+        attempted: usize,
+        failures: usize,
+        details: String,
+    },
+
     #[error("No root authority configured")]
     NoRootAuthority,
 
@@ -86,9 +93,10 @@ impl From<crate::commands::ext::SystemdError> for AvocadoError {
                 attempted,
                 failures,
                 details,
-            } => AvocadoError::UnmountFailed {
-                extension: format!("{failures} of {attempted}"),
-                reason: details,
+            } => AvocadoError::UnmountBatchFailed {
+                attempted,
+                failures,
+                details,
             },
         }
     }
@@ -159,5 +167,44 @@ impl From<crate::config::ConfigError> for AvocadoError {
         AvocadoError::ConfigurationError {
             message: e.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A batch unmount failure must keep its `attempted`/`failures` counts in
+    /// their own fields rather than stuffed into `UnmountFailed`'s `extension`
+    /// field, which every other producer of that variant (see
+    /// `commands::hitl::HitlError::Unmount` below) fills with a real mount
+    /// point name. Reusing the field for a count broke that contract for
+    /// anything reading `AvocadoError` structurally rather than as a rendered
+    /// string.
+    #[test]
+    fn unmount_batch_failure_keeps_the_count_out_of_the_extension_field() {
+        let sys_err = crate::commands::ext::SystemdError::UnmountBatchFailed {
+            attempted: 3,
+            failures: 2,
+            details: "a: busy; b: busy".to_string(),
+        };
+
+        let avocado_err = AvocadoError::from(sys_err);
+
+        assert!(
+            matches!(
+                avocado_err,
+                AvocadoError::UnmountBatchFailed {
+                    attempted: 3,
+                    failures: 2,
+                    ..
+                }
+            ),
+            "a batch failure must not be reshaped into UnmountFailed's per-extension fields"
+        );
+        assert_eq!(
+            avocado_err.to_string(),
+            "2 of 3 unmount operations failed: a: busy; b: busy"
+        );
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -122,7 +122,7 @@ pub fn perform_update(
         targets.signed.version, inline_count
     );
     if verbose {
-        for (name, _) in targets.signed.targets.iter() {
+        for name in targets.signed.targets.keys() {
             println!("    inline target: {}", name.raw());
         }
     }
@@ -162,7 +162,7 @@ pub fn perform_update(
                 delegation.signed.targets.len()
             );
             if verbose {
-                for (name, _) in delegation.signed.targets.iter() {
+                for name in delegation.signed.targets.keys() {
                     println!("    delegated target: {}", name.raw());
                 }
             }


### PR DESCRIPTION
Replacing an extension image and re-merging silently ran the old one. `ext status` said merged, the file's md5 matched the new image, and both unmerge and merge printed SUCCESS, while the device kept executing the previous contents until it happened to reboot. On a fleet that means an extension update can appear to apply and not.

Three defects in the `.raw` path combine to produce it:

1. **`RawAdaptor::is_mounted` tested for the loop, not the mount.** It checked `/dev/disk/by-loop-ref/<name>`. `systemd-dissect -U` unmounts the mount point but deliberately leaves a `--loop-ref` loop attached — that is what persistent means — so the symlink outlives the mount and the predicate reports mounted for something that is not. The caller then skips the remount and presents an extension whose contents are absent, which is how `docker.service` disappeared after an unmerge/merge cycle. `KabAdaptor` already pairs its loop check with `is_mount_active`; `RawAdaptor` now does the same.

2. **`RawAdaptor::unmount` left the loop attached.** Both callers — the `--unmount` teardown and the remount path — want the extension gone, so a surviving loop is never what was asked for: it keeps the old image open and the loop-ref pointing at it, so the next mount is skipped as already-mounted. It is detached now, which is also what `ext unmerge --unmount` has always claimed to do.

3. **`check_backing_file_changed` compared only the backing path.** An image replaced in place keeps its path *and* its inode, so the comparison saw no change while the loop still exposed the old image. It now also compares the loop's size against the file, which catches a replacement of a different size without hashing anything.

## Known gap

A same-size replacement still slips through. Catching that needs a fingerprint (inode + mtime + size) recorded at mount time and compared on merge; `/run` is the natural home since loops and `/run` share a lifetime. Left for a separate change rather than half-done here.

## Verification

- Compiles clean; 276 tests pass (272 existing + 4 new).
- The new tests cover `loop_size_matches`, including `saturating_mul` on a garbage sysfs read. The arithmetic is split into its own function precisely so it is testable — everything around it is gated behind `is_test_mode()` and cannot run under `cargo test`.
- No new clippy findings in the changed file.

**Not exercised on hardware.** The board runs the `avocadoctl` baked into its rootfs, so proving this end to end needs an image rebuild and a reflash. The reasoning traces directly to the observed failure, but that is weaker evidence than a hardware run and should be treated as such in review.

Originally found on FRDM-IMX93 updating a docker extension from 121126912 to 121131008 bytes: the merge reported success and the device kept running the previous image.

## Pre-existing, untouched

`cargo clippy --all-targets --all-features -- -D warnings` already fails on `main` with 4 warnings in `src/update.rs`. Not addressed here.
