### PR TITLE
refactor(config): make the configured state directories actually take effect

### DIFF
--- a/src/commands/ext.rs
+++ b/src/commands/ext.rs
@@ -149,14 +149,14 @@ pub fn handle_command(matches: &ArgMatches, config: &Config, output: &OutputMana
                 .get_many::<String>("names")
                 .map(|vs| vs.cloned().collect())
                 .unwrap_or_default();
-            set_extensions_enabled(&names, true, output);
+            set_extensions_enabled(&names, true, config, output);
         }
         Some(("disable", sub)) => {
             let names: Vec<String> = sub
                 .get_many::<String>("names")
                 .map(|vs| vs.cloned().collect())
                 .unwrap_or_default();
-            set_extensions_enabled(&names, false, output);
+            set_extensions_enabled(&names, false, config, output);
         }
         _ => {
             println!("Use 'avocadoctl ext --help' for available extension commands");
@@ -168,9 +168,14 @@ pub fn handle_command(matches: &ArgMatches, config: &Config, output: &OutputMana
 /// formats success / failure for the terminal. Used only by the
 /// `AVOCADO_TEST_MODE` direct dispatch path — the production path goes
 /// through varlink so the daemon owns serialization across callers.
-pub fn set_extensions_enabled(names: &[String], enabled: bool, output: &OutputManager) {
+pub fn set_extensions_enabled(
+    names: &[String],
+    enabled: bool,
+    config: &Config,
+    output: &OutputManager,
+) {
     let refs: Vec<&str> = names.iter().map(String::as_str).collect();
-    match crate::service::ext::set_extensions_enabled(&refs, enabled) {
+    match crate::service::ext::set_extensions_enabled(&refs, enabled, config) {
         Ok(result) => {
             let verb = if enabled { "enabled" } else { "disabled" };
             output.success(
@@ -195,16 +200,17 @@ pub fn set_extensions_enabled(names: &[String], enabled: bool, output: &OutputMa
 }
 
 /// List all extensions from disk images, annotating which are currently mounted/active.
-fn list_extensions(_config: &Config, output: &OutputManager) {
+fn list_extensions(config: &Config, output: &OutputManager) {
     output.info("Extension List", "Listing available extensions");
 
-    let available = match scan_extensions_from_all_sources_with_verbosity(output.is_verbose()) {
-        Ok(exts) => exts,
-        Err(e) => {
-            eprintln!("Error scanning extensions: {e}");
-            std::process::exit(1);
-        }
-    };
+    let available =
+        match scan_extensions_from_all_sources_with_verbosity(config, output.is_verbose()) {
+            Ok(exts) => exts,
+            Err(e) => {
+                eprintln!("Error scanning extensions: {e}");
+                std::process::exit(1);
+            }
+        };
 
     if available.is_empty() {
         println!("No extensions found.");
@@ -302,7 +308,7 @@ fn list_extensions(_config: &Config, output: &OutputManager) {
     // are effectively disabled. Surfaced separately so the user can see
     // them and know they exist to enable, rather than having them
     // silently vanish from `ext list`.
-    let base_dir = crate::manifest::RuntimeManifest::base_dir();
+    let base_dir = config.get_avocado_base_dir();
     let base_path = Path::new(&base_dir);
     if let Some(manifest) = crate::manifest::RuntimeManifest::load_active(base_path) {
         let active_dir = base_path.join(crate::manifest::ACTIVE_LINK_NAME);
@@ -553,7 +559,7 @@ pub(crate) fn merge_extensions_internal(
     );
 
     // Prepare the environment by setting up symlinks and get the list of enabled extensions
-    let enabled_extensions = prepare_extension_environment_with_output(output)?;
+    let enabled_extensions = prepare_extension_environment_with_output(config, output)?;
 
     // Get the mutability settings from config (separate for sysext and confext)
     let sysext_mutability = match config.get_sysext_mutable() {
@@ -740,12 +746,7 @@ pub fn enable_extensions(
     let extensions_dir = config.get_extensions_dir();
 
     // Determine os-releases directory based on test mode
-    let os_releases_dir = if std::env::var("AVOCADO_TEST_MODE").is_ok() {
-        let temp_base = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-        format!("{temp_base}/avocado/os-releases/{version_id}")
-    } else {
-        format!("/var/lib/avocado/os-releases/{version_id}")
-    };
+    let os_releases_dir = config.get_os_releases_dir(&version_id);
 
     // Create the os-releases directory if it doesn't exist
     if let Err(e) = fs::create_dir_all(&os_releases_dir) {
@@ -901,12 +902,7 @@ pub fn disable_extensions(
     );
 
     // Determine os-releases directory based on test mode
-    let os_releases_dir = if std::env::var("AVOCADO_TEST_MODE").is_ok() {
-        let temp_base = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-        format!("{temp_base}/avocado/os-releases/{version_id}")
-    } else {
-        format!("/var/lib/avocado/os-releases/{version_id}")
-    };
+    let os_releases_dir = config.get_os_releases_dir(&version_id);
 
     // Check if os-releases directory exists
     if !Path::new(&os_releases_dir).exists() {
@@ -1225,7 +1221,7 @@ pub(crate) fn collect_extension_status(
         .map(|m| m.extensions.as_slice())
         .unwrap_or(&[]);
 
-    let available_extensions = scan_extensions_from_all_sources_with_verbosity(false)?;
+    let available_extensions = scan_extensions_from_all_sources_with_verbosity(config, false)?;
     let mounted_sysext = get_mounted_systemd_extensions("systemd-sysext")?;
     let mounted_confext = get_mounted_systemd_extensions("systemd-confext")?;
 
@@ -1350,7 +1346,7 @@ pub(crate) fn show_enhanced_status(
 
     // Get our view of available extensions
     let available_extensions =
-        scan_extensions_from_all_sources_with_verbosity(output.is_verbose())?;
+        scan_extensions_from_all_sources_with_verbosity(config, output.is_verbose())?;
 
     // Get systemd's view of mounted extensions
     let mounted_sysext = get_mounted_systemd_extensions("systemd-sysext")?;
@@ -1980,6 +1976,7 @@ fn format_status_output(output: &str) {
 
 /// Prepare the extension environment by setting up symlinks with output manager
 fn prepare_extension_environment_with_output(
+    config: &Config,
     output: &OutputManager,
 ) -> Result<Vec<Extension>, SystemdError> {
     output.step("Environment", "Preparing extension environment");
@@ -1988,7 +1985,7 @@ fn prepare_extension_environment_with_output(
     verify_clean_extension_environment(output)?;
 
     // Scan for available extensions from multiple sources
-    let extensions = scan_extensions_from_all_sources_with_verbosity(output.is_verbose())?;
+    let extensions = scan_extensions_from_all_sources_with_verbosity(config, output.is_verbose())?;
 
     if extensions.is_empty() {
         output.progress("No extensions found in any source location");
@@ -2212,6 +2209,7 @@ pub(crate) fn read_os_version_id() -> String {
 
 /// Scan all extension sources in priority order with verbosity control
 fn scan_extensions_from_all_sources_with_verbosity(
+    config: &Config,
     verbose: bool,
 ) -> Result<Vec<Extension>, SystemdError> {
     let mut extensions = Vec::new();
@@ -2228,9 +2226,13 @@ fn scan_extensions_from_all_sources_with_verbosity(
     // Read OS VERSION_ID for runtime-specific extensions
     let version_id = read_os_version_id();
 
-    // Fallback to the images directory where extension images are installed
-    let extensions_dir = std::env::var("AVOCADO_EXTENSIONS_PATH")
-        .unwrap_or_else(|_| "/var/lib/avocado/images".to_string());
+    // Where extension images are installed. Goes through the config
+    // accessor (which still lets AVOCADO_EXTENSIONS_PATH win) rather than
+    // reading the env var against a private hardcoded default: this is
+    // the scan that decides what actually gets merged, so reading a
+    // different directory than every other code path is the one place
+    // the inconsistency is guaranteed to be visible.
+    let extensions_dir = config.get_extensions_dir();
 
     // 1. First priority: HITL mounted extensions
     if verbose {
@@ -2251,7 +2253,7 @@ fn scan_extensions_from_all_sources_with_verbosity(
 
     // 2. Second priority: Active runtime manifest
     // If a manifest exists, use it to determine extensions and skip legacy os-releases scanning
-    let base_dir = crate::manifest::RuntimeManifest::base_dir();
+    let base_dir = config.get_avocado_base_dir();
     let base_path = Path::new(&base_dir);
     let active_manifest = crate::manifest::RuntimeManifest::load_active(base_path);
     let used_manifest = if let Some(ref manifest) = active_manifest {
@@ -2374,12 +2376,7 @@ fn scan_extensions_from_all_sources_with_verbosity(
     // Legacy extension discovery: only used when no manifest is present
     if !used_manifest {
         // 2b. Legacy: OS release-specific extensions (/var/lib/avocado/os-releases/<VERSION_ID>)
-        let os_releases_extensions_dir = if std::env::var("AVOCADO_TEST_MODE").is_ok() {
-            let temp_base = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-            format!("{temp_base}/avocado/os-releases/{version_id}")
-        } else {
-            format!("/var/lib/avocado/os-releases/{version_id}")
-        };
+        let os_releases_extensions_dir = config.get_os_releases_dir(&version_id);
 
         if verbose {
             println!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,6 +176,24 @@ impl Config {
         })
     }
 
+    /// Per-OS-version directory holding the enable/disable symlinks for
+    /// `version_id`.
+    ///
+    /// Derived from [`Self::get_avocado_base_dir`] so relocating the base
+    /// directory moves enablement state with it. Five call sites used to
+    /// inline `/var/lib/avocado/os-releases/{version_id}` with a private
+    /// `AVOCADO_TEST_MODE` branch, which meant configuring the base
+    /// directory silently failed to move this one — the merge path read
+    /// enablement from a directory nothing else agreed on. The test-mode
+    /// redirect is preserved here so it stays in one place.
+    pub fn get_os_releases_dir(&self, version_id: &str) -> String {
+        if std::env::var("AVOCADO_TEST_MODE").is_ok() {
+            let temp_base = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
+            return format!("{temp_base}/avocado/os-releases/{version_id}");
+        }
+        format!("{}/os-releases/{version_id}", self.get_avocado_base_dir())
+    }
+
     /// Get the spot check size in bytes for integrity hashing during merge.
     pub fn get_spot_check_bytes(&self) -> u64 {
         self.avocado.ext.spot_check_bytes
@@ -733,5 +751,92 @@ dir = "/override/test/path"
         // Test with default path (should return default config since default doesn't exist)
         let default_config = Config::load_with_override(None).unwrap();
         assert_eq!(default_config.avocado.ext.dir, "/var/lib/avocado/images");
+    }
+
+    /// The point of the change: setting the base directory in the config
+    /// file must actually move enablement state. Before, five call sites
+    /// inlined `/var/lib/avocado/os-releases/…` and this was silently a
+    /// no-op.
+    #[test]
+    fn os_releases_dir_follows_the_configured_base_dir() {
+        let _guard = ENV_VAR_MUTEX.lock().unwrap();
+        let restore = ScopedEnv::clear(&["AVOCADO_TEST_MODE", "AVOCADO_BASE_DIR"]);
+
+        let mut config = Config::default();
+        config.avocado.runtimes_dir = Some("/mnt/state/avocado".to_string());
+        assert_eq!(
+            config.get_os_releases_dir("2026.1"),
+            "/mnt/state/avocado/os-releases/2026.1"
+        );
+
+        // Unconfigured still lands on the shipped default.
+        assert_eq!(
+            Config::default().get_os_releases_dir("2026.1"),
+            "/var/lib/avocado/os-releases/2026.1"
+        );
+        drop(restore);
+    }
+
+    #[test]
+    fn os_releases_dir_honours_the_base_dir_env_override() {
+        let _guard = ENV_VAR_MUTEX.lock().unwrap();
+        let restore = ScopedEnv::clear(&["AVOCADO_TEST_MODE"]);
+        std::env::set_var("AVOCADO_BASE_DIR", "/env/base");
+
+        let mut config = Config::default();
+        config.avocado.runtimes_dir = Some("/config/base".to_string());
+        // Env wins over config, matching get_avocado_base_dir.
+        assert_eq!(config.get_os_releases_dir("v1"), "/env/base/os-releases/v1");
+
+        std::env::remove_var("AVOCADO_BASE_DIR");
+        drop(restore);
+    }
+
+    /// Test mode redirects to TMPDIR regardless of config, and now does so
+    /// from a single place rather than five copies that could drift.
+    #[test]
+    fn test_mode_redirects_os_releases_to_tmpdir() {
+        let _guard = ENV_VAR_MUTEX.lock().unwrap();
+        let restore = ScopedEnv::clear(&[]);
+        std::env::set_var("AVOCADO_TEST_MODE", "1");
+        std::env::set_var("TMPDIR", "/scratch");
+
+        let mut config = Config::default();
+        config.avocado.runtimes_dir = Some("/mnt/state/avocado".to_string());
+        assert_eq!(
+            config.get_os_releases_dir("v1"),
+            "/scratch/avocado/os-releases/v1"
+        );
+
+        std::env::remove_var("AVOCADO_TEST_MODE");
+        drop(restore);
+    }
+
+    /// Saves and restores env vars around a test so the shared process
+    /// environment doesn't leak between them.
+    struct ScopedEnv(Vec<(String, Option<String>)>);
+
+    impl ScopedEnv {
+        fn clear(names: &[&str]) -> Self {
+            let saved: Vec<_> = ["AVOCADO_TEST_MODE", "AVOCADO_BASE_DIR", "TMPDIR"]
+                .iter()
+                .map(|n| (n.to_string(), std::env::var(n).ok()))
+                .collect();
+            for n in names {
+                std::env::remove_var(n);
+            }
+            Self(saved)
+        }
+    }
+
+    impl Drop for ScopedEnv {
+        fn drop(&mut self) {
+            for (name, value) in &self.0 {
+                match value {
+                    Some(v) => std::env::set_var(name, v),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -101,11 +101,6 @@ impl RuntimeManifest {
         })
     }
 
-    /// Resolve the avocado base directory, checking env override for testing.
-    pub fn base_dir() -> String {
-        std::env::var("AVOCADO_BASE_DIR").unwrap_or_else(|_| DEFAULT_AVOCADO_DIR.to_string())
-    }
-
     /// Load a manifest from a specific directory containing manifest.json.
     pub fn load_from(dir: &Path) -> Option<Self> {
         let manifest_path = dir.join(MANIFEST_FILENAME);

--- a/src/service/ext.rs
+++ b/src/service/ext.rs
@@ -170,12 +170,7 @@ pub fn enable_extensions(
     let extensions_dir = config.get_extensions_dir();
 
     // Determine os-releases directory
-    let os_releases_dir = if std::env::var("AVOCADO_TEST_MODE").is_ok() {
-        let temp_base = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-        format!("{temp_base}/avocado/os-releases/{version_id}")
-    } else {
-        format!("/var/lib/avocado/os-releases/{version_id}")
-    };
+    let os_releases_dir = config.get_os_releases_dir(&version_id);
 
     // Create directory
     fs::create_dir_all(&os_releases_dir).map_err(|e| AvocadoError::ConfigurationError {
@@ -247,18 +242,14 @@ pub fn disable_extensions(
     os_release_version: Option<&str>,
     extensions: Option<&[&str]>,
     all: bool,
+    config: &Config,
 ) -> Result<DisableResult, AvocadoError> {
     let version_id = match os_release_version {
         Some(v) => v.to_string(),
         None => ext::read_os_version_id(),
     };
 
-    let os_releases_dir = if std::env::var("AVOCADO_TEST_MODE").is_ok() {
-        let temp_base = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-        format!("{temp_base}/avocado/os-releases/{version_id}")
-    } else {
-        format!("/var/lib/avocado/os-releases/{version_id}")
-    };
+    let os_releases_dir = config.get_os_releases_dir(&version_id);
 
     if !Path::new(&os_releases_dir).exists() {
         return Err(AvocadoError::ConfigurationError {
@@ -355,8 +346,9 @@ pub fn status_extensions(
 pub fn set_extensions_enabled(
     names: &[&str],
     enabled: bool,
+    config: &Config,
 ) -> Result<SetEnabledResult, AvocadoError> {
-    let base_dir = crate::manifest::RuntimeManifest::base_dir();
+    let base_dir = config.get_avocado_base_dir();
     let base_path = std::path::Path::new(&base_dir);
     let manifest = crate::manifest::RuntimeManifest::load_active(base_path).ok_or_else(|| {
         AvocadoError::ConfigurationError {

--- a/src/varlink_server.rs
+++ b/src/varlink_server.rs
@@ -184,6 +184,7 @@ impl vl_ext::VarlinkInterface for ExtensionsHandler {
             osRelease.as_deref(),
             ext_refs.as_deref(),
             all.unwrap_or(false),
+            &self.config,
         ) {
             Ok(result) => call.reply(result.disabled as i64, result.failed as i64),
             Err(e) => map_ext_error!(call, e),
@@ -204,7 +205,7 @@ impl vl_ext::VarlinkInterface for ExtensionsHandler {
         r#enabled: bool,
     ) -> varlink::Result<()> {
         let ext_refs: Vec<&str> = extensions.iter().map(|s| s.as_str()).collect();
-        match service::ext::set_extensions_enabled(&ext_refs, enabled) {
+        match service::ext::set_extensions_enabled(&ext_refs, enabled, &self.config) {
             Ok(result) => call.reply(result.updated as i64, result.missing as i64),
             Err(e) => map_ext_error!(call, e),
         }


### PR DESCRIPTION
## Problem

`avocado.ext.dir` and `avocado.runtimes_dir` exist in `/etc/avocado/avocadoctl.conf`, but setting them only moved *some* of the code that resolves state paths. Three separate pathways disagreed about where state lives:

**1. The merge scan ignored `ext.dir` entirely.** `scan_extensions_from_all_sources_with_verbosity` read `AVOCADO_EXTENSIONS_PATH` against a private hardcoded `/var/lib/avocado/images` fallback:

```rust
let extensions_dir = std::env::var("AVOCADO_EXTENSIONS_PATH")
    .unwrap_or_else(|_| "/var/lib/avocado/images".to_string());
```

This is the scan that decides what actually gets merged. Configuring the images directory moved every other reader and left this one behind — the worst possible split.

**2. Five call sites inlined the os-releases path**, each with its own copy of the `AVOCADO_TEST_MODE` branch (`service/ext.rs` ×2, `commands/ext.rs` ×3). Enablement symlinks stayed at `/var/lib/avocado/os-releases/…` no matter what the base directory was set to.

**3. `RuntimeManifest::base_dir()` was a second resolver** that read only `AVOCADO_BASE_DIR` and never the config file — used by three callers that each already had a `Config` in scope.

## Change

Everything resolves through the existing accessors. Adds `Config::get_os_releases_dir(version_id)`, derived from `get_avocado_base_dir()`, and deletes `RuntimeManifest::base_dir()` so there is one resolver instead of two.

`config` is threaded into `disable_extensions`, `set_extensions_enabled`, `prepare_extension_environment_with_output` and the merge scan. Three of the scan's four callers already had one.

**Defaults and precedence are unchanged** — env override, then config, then the same shipped paths. The `AVOCADO_TEST_MODE` redirect now lives in one place rather than five copies free to drift.

## Testing

Three new cases pinning the behaviour that was previously unreachable:

- a configured base directory moves `os-releases` with it
- `AVOCADO_BASE_DIR` still wins over config, matching `get_avocado_base_dir`
- test mode redirects to `TMPDIR` regardless of config

Full suite green (275 tests), `cargo fmt` clean. The two `clippy` warnings in `src/update.rs` are pre-existing on `main`.

## Context

Prerequisite for moving the VM's Avocado state out of `/var` onto a read-only image shipped with the rootfs — that needs the state directory to be genuinely relocatable by config. Independent of that work and correct on its own. Does not depend on #18.

---

## Verified in a real VM

Built into an image via meta-avocado (`SRCBRANCH` pinned to a branch carrying this PR), then used to migrate a stock avocado-vm 0.3.0 to a locally built release.

Confirmed the running guest binary was this code, not stock — `Failed to stage active runtime link` is a string that exists only in this PR and is present in `/usr/bin/avocadoctl` in the booted VM.

The migration exercised `add_from_manifest` → `activate_runtime` and passed 8/8: active runtime switched, all extensions merged, and the user's Docker volume, image layers and `/var` marker survived with `var.btrfs` the same inode throughout.