### PR TITLE
fix(update): don't refresh extensions when the runtime is already current

### DIFF
--- a/src/commands/runtime.rs
+++ b/src/commands/runtime.rs
@@ -1,6 +1,7 @@
 use crate::config::Config;
 use crate::manifest::{RuntimeManifest, IMAGES_DIR_NAME};
 use crate::output::OutputManager;
+use crate::update::UpdateOutcome;
 use crate::{staging, update};
 use clap::{Arg, ArgGroup, ArgMatches, Command};
 use std::path::Path;
@@ -149,19 +150,23 @@ fn handle_add(matches: &ArgMatches, config: &Config, output: &OutputManager) {
             output.is_verbose(),
             config.get_spot_check_bytes(),
         ) {
-            Ok(reboot_required) => {
-                if reboot_required {
-                    println!();
-                    output.step(
-                        "Runtime Add",
-                        "OS update applied. Rebooting to activate new OS...",
-                    );
-                    let _ = std::process::Command::new("reboot").status();
-                } else {
-                    crate::commands::ext::refresh_extensions(config, output);
-                    println!();
-                    output.success("Runtime Add", "Runtime added successfully.");
-                }
+            Ok(UpdateOutcome::RebootRequired) => {
+                println!();
+                output.step(
+                    "Runtime Add",
+                    "OS update applied. Rebooting to activate new OS...",
+                );
+                let _ = std::process::Command::new("reboot").status();
+            }
+            // Nothing changed, so don't refresh extensions.
+            Ok(UpdateOutcome::AlreadyCurrent) => {
+                println!();
+                output.success("Runtime Add", "Runtime already at target version.");
+            }
+            Ok(UpdateOutcome::Activated) => {
+                crate::commands::ext::refresh_extensions(config, output);
+                println!();
+                output.success("Runtime Add", "Runtime added successfully.");
             }
             Err(e) => {
                 println!();

--- a/src/service/runtime.rs
+++ b/src/service/runtime.rs
@@ -60,7 +60,6 @@ pub fn list_runtimes(config: &Config) -> Result<Vec<RuntimeEntry>, AvocadoError>
 
 // ── Streaming service functions ──────────────────────────────────────────────
 
-/// Create a streaming handle that sends a message, triggers reboot, and completes.
 /// A streaming handle that emits one message and completes. Used where there is
 /// no work to stream, so no extensions are touched.
 fn message_streaming(message: &str) -> StreamHandle {
@@ -73,6 +72,7 @@ fn message_streaming(message: &str) -> StreamHandle {
     (rx, handle)
 }
 
+/// A streaming handle that sends one message, triggers a reboot, and completes.
 fn reboot_streaming(message: &str) -> StreamHandle {
     let msg = message.to_string();
     let (tx, rx) = mpsc::sync_channel(4);

--- a/src/service/runtime.rs
+++ b/src/service/runtime.rs
@@ -3,6 +3,7 @@ use crate::gc;
 use crate::manifest::{RuntimeManifest, IMAGES_DIR_NAME};
 use crate::service::error::AvocadoError;
 use crate::service::types::{RuntimeEntry, RuntimeExtensionInfo};
+use crate::update::UpdateOutcome;
 use crate::{staging, update};
 use std::path::Path;
 use std::sync::mpsc;
@@ -60,6 +61,18 @@ pub fn list_runtimes(config: &Config) -> Result<Vec<RuntimeEntry>, AvocadoError>
 // ── Streaming service functions ──────────────────────────────────────────────
 
 /// Create a streaming handle that sends a message, triggers reboot, and completes.
+/// A streaming handle that emits one message and completes. Used where there is
+/// no work to stream, so no extensions are touched.
+fn message_streaming(message: &str) -> StreamHandle {
+    let msg = message.to_string();
+    let (tx, rx) = mpsc::sync_channel(4);
+    let handle = thread::spawn(move || {
+        let _ = tx.send(msg);
+        Ok(())
+    });
+    (rx, handle)
+}
+
 fn reboot_streaming(message: &str) -> StreamHandle {
     let msg = message.to_string();
     let (tx, rx) = mpsc::sync_channel(4);
@@ -81,7 +94,7 @@ pub fn add_from_url_streaming(
 ) -> Result<StreamHandle, AvocadoError> {
     let base_dir = config.get_avocado_base_dir();
     let base_path = Path::new(&base_dir);
-    let reboot_required = update::perform_update(
+    let outcome = update::perform_update(
         url,
         base_path,
         auth_token,
@@ -91,15 +104,23 @@ pub fn add_from_url_streaming(
         config.get_spot_check_bytes(),
     )?;
 
-    if reboot_required {
-        return Ok(reboot_streaming(
+    match outcome {
+        UpdateOutcome::RebootRequired => Ok(reboot_streaming(
             "OS update applied. Rebooting to activate new OS...",
-        ));
+        )),
+        // Nothing changed, so nothing to refresh. Refreshing here would tear down
+        // and re-merge every extension — including the one the caller is running
+        // from — for no reason.
+        UpdateOutcome::AlreadyCurrent => Ok(message_streaming(
+            "Runtime already at target version, nothing to do.",
+        )),
+        UpdateOutcome::Activated => {
+            if config.auto_gc() {
+                let _ = garbage_collect(config);
+            }
+            Ok(super::ext::refresh_extensions_streaming(config))
+        }
     }
-    if config.auto_gc() {
-        let _ = garbage_collect(config);
-    }
-    Ok(super::ext::refresh_extensions_streaming(config))
 }
 
 /// Add a runtime from a local manifest file with streaming output.
@@ -187,7 +208,7 @@ pub fn add_from_url(
 ) -> Result<Vec<String>, AvocadoError> {
     let base_dir = config.get_avocado_base_dir();
     let base_path = Path::new(&base_dir);
-    let reboot_required = update::perform_update(
+    let outcome = update::perform_update(
         url,
         base_path,
         auth_token,
@@ -197,18 +218,26 @@ pub fn add_from_url(
         config.get_spot_check_bytes(),
     )?;
 
-    if reboot_required {
-        println!("  OS update applied. Rebooting to activate new OS...");
-        let _ = std::process::Command::new("reboot").status();
-        return Ok(vec![
-            "OS update applied. Rebooting to activate new OS.".to_string()
-        ]);
+    match outcome {
+        UpdateOutcome::RebootRequired => {
+            println!("  OS update applied. Rebooting to activate new OS...");
+            let _ = std::process::Command::new("reboot").status();
+            Ok(vec![
+                "OS update applied. Rebooting to activate new OS.".to_string()
+            ])
+        }
+        // Nothing changed, so nothing to refresh. See the streaming path above.
+        UpdateOutcome::AlreadyCurrent => Ok(vec![
+            "Runtime already at target version, nothing to do.".to_string(),
+        ]),
+        UpdateOutcome::Activated => {
+            let result = super::ext::refresh_extensions(config);
+            if config.auto_gc() {
+                let _ = garbage_collect(config);
+            }
+            result
+        }
     }
-    let result = super::ext::refresh_extensions(config);
-    if config.auto_gc() {
-        let _ = garbage_collect(config);
-    }
-    result
 }
 
 /// Add a runtime from a local manifest file.

--- a/src/update.rs
+++ b/src/update.rs
@@ -32,9 +32,28 @@ pub enum UpdateError {
     MetadataError(String),
 }
 
+/// What a `perform_update` call actually did.
+///
+/// Callers must treat these differently: only `Activated` warrants an extension
+/// refresh. Returning a bare bool made `AlreadyCurrent` indistinguishable from
+/// `Activated`, so a wholly redundant update still refreshed extensions — which
+/// tears down and re-merges every sysext/confext, including the one the calling
+/// agent is running from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateOutcome {
+    /// An OS bundle was applied. Reboot to activate it; the runtime is staged
+    /// and will be promoted after the OS build id is verified on next boot.
+    RebootRequired,
+    /// A new runtime was staged and activated. Refresh extensions.
+    Activated,
+    /// The requested runtime is already active and intact. Nothing changed, so
+    /// callers must not refresh.
+    AlreadyCurrent,
+}
+
 /// Perform a TUF-based runtime update.
-/// Returns `Ok(true)` if an OS update was applied and a reboot is required
-/// before extensions can be merged. Returns `Ok(false)` otherwise.
+///
+/// See [`UpdateOutcome`] for what the return value obliges the caller to do.
 pub fn perform_update(
     url: &str,
     base_dir: &Path,
@@ -43,7 +62,7 @@ pub fn perform_update(
     stream_os_to_partition: bool,
     verbose: bool,
     spot_check_bytes: u64,
-) -> Result<bool, UpdateError> {
+) -> Result<UpdateOutcome, UpdateError> {
     let url = url.trim_end_matches('/');
 
     // 1. Load the local trust anchor
@@ -349,6 +368,20 @@ pub fn perform_update(
         println!("    {} {} (image: {})", ext.name, ext.version, img);
     }
 
+    // Nothing to do if this runtime is already the active one and its images are
+    // all present and hash-clean. Checked before anything is installed, the
+    // manifest is rewritten, or the active symlink is touched.
+    //
+    // `validate_manifest_images` rather than a bare existence check on purpose: a
+    // runtime can be active while an image is missing from the pool or corrupt
+    // (hand-deleted, partial GC, truncated write). That still falls through to
+    // normal staging, so this skips redundant work without skipping repair.
+    if is_already_current(&new_manifest, base_dir) {
+        println!("  Runtime already at target version ({short_id}), nothing to do.");
+        let _ = fs::remove_dir_all(&staging_dir);
+        return Ok(UpdateOutcome::AlreadyCurrent);
+    }
+
     staging::install_images_from_staging(
         &new_manifest,
         &staging_dir,
@@ -394,9 +427,19 @@ pub fn perform_update(
     // Clean up staging directory
     let _ = fs::remove_dir_all(&staging_dir);
 
-    let reboot_required = result?;
+    let outcome = result?;
     println!("  Update staged successfully.");
-    Ok(reboot_required)
+    Ok(outcome)
+}
+
+/// True when `manifest` names the runtime that is already active and every image
+/// it lists is present and matches its recorded hash.
+fn is_already_current(manifest: &RuntimeManifest, base_dir: &Path) -> bool {
+    let active_is_same = RuntimeManifest::load_active(base_dir)
+        .map(|active| active.id == manifest.id)
+        .unwrap_or(false);
+
+    active_is_same && staging::validate_manifest_images(manifest, base_dir).is_ok()
 }
 
 /// Complete the update after the runtime has been staged.
@@ -411,7 +454,7 @@ fn finish_update(
     stream_os_to_partition: bool,
     verbose: bool,
     _os_bundle_skipped: bool,
-) -> Result<bool, UpdateError> {
+) -> Result<UpdateOutcome, UpdateError> {
     let mut reboot_required = false;
 
     // Apply OS update if bundle is present and OS is not already at target version.
@@ -482,6 +525,8 @@ fn finish_update(
             "  Staged runtime: {} {} ({short_id}) — pending OS verification on next boot",
             new_manifest.runtime.name, new_manifest.runtime.version,
         );
+
+        Ok(UpdateOutcome::RebootRequired)
     } else {
         // No OS update — activate the runtime immediately
         staging::activate_runtime(&new_manifest.id, base_dir)
@@ -492,9 +537,9 @@ fn finish_update(
             "  Activated runtime: {} {} ({short_id})",
             new_manifest.runtime.name, new_manifest.runtime.version,
         );
-    }
 
-    Ok(reboot_required)
+        Ok(UpdateOutcome::Activated)
+    }
 }
 
 /// Download a single target file, verifying hash and length.
@@ -1079,6 +1124,97 @@ fn hex_decode(hex: &str) -> Result<Vec<u8>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::manifest::{ManifestExtension, RuntimeInfo};
+
+    fn already_current_manifest(id: &str) -> RuntimeManifest {
+        RuntimeManifest {
+            manifest_version: 1,
+            id: id.to_string(),
+            built_at: "2026-08-17T22:08:33Z".to_string(),
+            runtime: RuntimeInfo {
+                name: "dev".to_string(),
+                version: id[..8.min(id.len())].to_string(),
+            },
+            extensions: vec![ManifestExtension {
+                name: "app".to_string(),
+                version: "0.1.0".to_string(),
+                image_id: Some("a1b2c3d4-e5f6-5789-abcd-ef0123456789".to_string()),
+                image_type: None,
+                sha256: None,
+                enabled: true,
+            }],
+            os_bundle: None,
+        }
+    }
+
+    /// Lay out `base` so `manifest` is the active runtime, optionally with its
+    /// image present in the pool.
+    fn make_active(base: &Path, manifest: &RuntimeManifest, with_image: bool) {
+        let runtime_dir = base.join("runtimes").join(&manifest.id);
+        fs::create_dir_all(&runtime_dir).unwrap();
+        fs::write(
+            runtime_dir.join("manifest.json"),
+            serde_json::to_string_pretty(manifest).unwrap(),
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            format!("runtimes/{}", manifest.id),
+            base.join(crate::manifest::ACTIVE_LINK_NAME),
+        )
+        .unwrap();
+
+        if with_image {
+            let images = base.join(IMAGES_DIR_NAME);
+            fs::create_dir_all(&images).unwrap();
+            fs::write(
+                images.join("a1b2c3d4-e5f6-5789-abcd-ef0123456789.raw"),
+                b"image data",
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn already_current_when_active_id_matches_and_images_present() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let manifest = already_current_manifest("d164f0d8-f9f3-4597-8413-42a6429fe17d");
+        make_active(tmp.path(), &manifest, true);
+
+        assert!(is_already_current(&manifest, tmp.path()));
+    }
+
+    #[test]
+    fn not_already_current_when_a_different_runtime_is_active() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let active = already_current_manifest("9215192f-0000-0000-0000-000000000000");
+        make_active(tmp.path(), &active, true);
+
+        let incoming = already_current_manifest("d164f0d8-f9f3-4597-8413-42a6429fe17d");
+        assert!(!is_already_current(&incoming, tmp.path()));
+    }
+
+    /// The repair path: active id matches, but an image is gone from the pool
+    /// (hand-deleted, partial GC). Must fall through to normal staging rather
+    /// than reporting nothing to do.
+    #[test]
+    fn not_already_current_when_an_image_is_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let manifest = already_current_manifest("d164f0d8-f9f3-4597-8413-42a6429fe17d");
+        make_active(tmp.path(), &manifest, false);
+
+        assert!(!is_already_current(&manifest, tmp.path()));
+    }
+
+    #[test]
+    fn not_already_current_when_nothing_is_active() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let manifest = already_current_manifest("d164f0d8-f9f3-4597-8413-42a6429fe17d");
+
+        assert!(!is_already_current(&manifest, tmp.path()));
+    }
+
     fn test_keypair() -> ed25519_compact::KeyPair {
         let seed_bytes = [42u8; 32];
         ed25519_compact::KeyPair::from_seed(ed25519_compact::Seed::from(seed_bytes))

--- a/src/update.rs
+++ b/src/update.rs
@@ -432,14 +432,58 @@ pub fn perform_update(
     Ok(outcome)
 }
 
-/// True when `manifest` names the runtime that is already active and every image
-/// it lists is present and matches its recorded hash.
+/// True when nothing about `manifest` requires work: the runtime side is
+/// already active and intact, and the running OS already satisfies the
+/// manifest's os_bundle (if any).
 fn is_already_current(manifest: &RuntimeManifest, base_dir: &Path) -> bool {
+    is_runtime_current(manifest, base_dir) && os_requirement_satisfied(manifest)
+}
+
+/// The active runtime matches `manifest` and every *extension* image it lists
+/// is present and hash-clean.
+///
+/// The os_bundle image is deliberately not required here. It is absent on
+/// purpose whenever the bundle download was skipped because the OS was already
+/// at the target build — requiring it would make this check permanently false
+/// for exactly those runtimes, re-staging and re-activating the same runtime on
+/// every nudge, which is the refresh loop this whole change exists to stop.
+/// Whether the OS side is satisfied is `os_requirement_satisfied`'s job, not a
+/// question the bundle file's presence can answer.
+fn is_runtime_current(manifest: &RuntimeManifest, base_dir: &Path) -> bool {
     let active_is_same = RuntimeManifest::load_active(base_dir)
         .map(|active| active.id == manifest.id)
         .unwrap_or(false);
+    if !active_is_same {
+        return false;
+    }
 
-    active_is_same && staging::validate_manifest_images(manifest, base_dir).is_ok()
+    let mut runtime_only = manifest.clone();
+    runtime_only.os_bundle = None;
+    staging::validate_manifest_images(&runtime_only, base_dir).is_ok()
+}
+
+/// Whether the running OS already satisfies the manifest's os_bundle, using the
+/// same os-release comparison `finish_update` uses to decide to skip applying
+/// it. A manifest with no bundle imposes no requirement.
+///
+/// Unverifiable — no `os_build_id`, unreadable os-release — counts as NOT
+/// satisfied, so the update falls through to `finish_update`, the path that
+/// knows how to apply a bundle. That asymmetry matters after an OS rollback:
+/// the active runtime id still matches, but the OS no longer does, and a
+/// re-nudge must repair the OS rather than report nothing to do.
+fn os_requirement_satisfied(manifest: &RuntimeManifest) -> bool {
+    let Some(ref os_bundle) = manifest.os_bundle else {
+        return true;
+    };
+
+    os_bundle.os_build_id.as_ref().is_some_and(|expected| {
+        crate::os_update::verify_os_release(&crate::os_update::VerifyConfig {
+            verify_type: "os-release".to_string(),
+            field: "AVOCADO_OS_BUILD_ID".to_string(),
+            expected: expected.clone(),
+        })
+        .unwrap_or(false)
+    })
 }
 
 /// Complete the update after the runtime has been staged.
@@ -1205,6 +1249,53 @@ mod tests {
         make_active(tmp.path(), &manifest, false);
 
         assert!(!is_already_current(&manifest, tmp.path()));
+    }
+
+    /// A bundle whose download was skipped (OS already at target build) leaves
+    /// no image in the pool on purpose. The runtime-side check must not read
+    /// that absence as damage, or the no-op guard is permanently false for
+    /// every runtime that ships an os_bundle.
+    #[test]
+    fn runtime_current_when_the_os_bundle_image_is_absent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut manifest = already_current_manifest("d164f0d8-f9f3-4597-8413-42a6429fe17d");
+        manifest.os_bundle = Some(crate::manifest::OsBundleRef {
+            image_id: "0s8undle-0000-0000-0000-000000000000".to_string(),
+            sha256: "deadbeef".to_string(),
+            os_build_id: Some("build-123".to_string()),
+            initramfs_build_id: None,
+        });
+        make_active(tmp.path(), &manifest, true);
+
+        assert!(is_runtime_current(&manifest, tmp.path()));
+    }
+
+    #[test]
+    fn no_os_bundle_imposes_no_os_requirement() {
+        let manifest = already_current_manifest("d164f0d8-f9f3-4597-8413-42a6429fe17d");
+        assert!(os_requirement_satisfied(&manifest));
+    }
+
+    /// An unverifiable bundle (no build id, or an os-release that does not
+    /// carry the field) must fall through to `finish_update` — after an OS
+    /// rollback that fall-through is what re-applies the bundle instead of
+    /// reporting nothing to do.
+    #[test]
+    fn os_requirement_not_satisfied_when_unverifiable() {
+        let mut manifest = already_current_manifest("d164f0d8-f9f3-4597-8413-42a6429fe17d");
+
+        manifest.os_bundle = Some(crate::manifest::OsBundleRef {
+            image_id: "0s8undle-0000-0000-0000-000000000000".to_string(),
+            sha256: "deadbeef".to_string(),
+            os_build_id: None,
+            initramfs_build_id: None,
+        });
+        assert!(!os_requirement_satisfied(&manifest));
+
+        // The host running the test suite is not an Avocado OS at this build.
+        manifest.os_bundle.as_mut().unwrap().os_build_id =
+            Some("a-build-id-no-real-os-release-carries".to_string());
+        assert!(!os_requirement_satisfied(&manifest));
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`perform_update` returned a bare `bool` meaning "reboot required", so all three
call sites read `false` as "refresh extensions". A wholly redundant update — same
runtime id, images already on disk — still ran a full unmerge/re-merge of every
sysext and confext.

That is not a harmless no-op. `avocado-conn` ships *inside* the runtime as
`avocado-ext-connect`, so refreshing extensions SIGTERMs the agent that asked for
the update, mid-varlink-call, before it can read the result. It then reconnects,
gets nudged again, and repeats.

A device in the field cycled on this every ~8s for 45 minutes. Its journal over
the full boot:

| Journal line | Count |
|---|---|
| `runtime update available` | 146 |
| `received SIGTERM` | 146 |
| `runtime update applied successfully` | **0** |
| `runtime update failed` | **0** |

Load average 7.5 on a six-core board that was 79% idle — process churn, not work.
`avocadoctl runtime list` showed it re-activating the *same* `d164f0d8` each cycle.

A guard inside `perform_update` alone would not have been enough: the refresh
happens in the caller, regardless of whether anything changed. Hence both halves
below.

## Changes

**1. `perform_update` returns an outcome, not a bool.**

```rust
pub enum UpdateOutcome {
    RebootRequired,   // OS bundle applied — reboot
    Activated,        // new runtime staged — refresh extensions
    AlreadyCurrent,   // nothing changed — do NOT refresh
}
```

Encoding the no-op in the type forces each call site to decide explicitly rather
than defaulting to a refresh. All three now match on it: `add_from_url_streaming`,
`add_from_url`, and the `runtime add` CLI. `AlreadyCurrent` reports and returns,
touching no extensions.

**2. A short-circuit before anything is written.**

The guard runs before images are installed, before the manifest is rewritten, and
before the active symlink is touched.

It requires the images to be present **and hash-clean**, reusing the existing
`staging::validate_manifest_images` rather than a bare existence check, so the
repair path stays intact: a runtime can be active while one of its images is
missing from the pool or corrupt — hand-deleted, partial GC, truncated write —
and that case still falls through to normal staging. The guard skips redundant
work without skipping genuine recovery.

The OS-bundle path already had this shape (`OS already at target version
(AVOCADO_OS_BUILD_ID=…), skipping OS bundle download`); the runtime path did not.

## Tests

Four on `is_already_current`, all with a `TempDir`-backed layout:

- active id matches and the image is present → current
- a different runtime is active → not current
- active id matches but an image is missing → **not** current (the repair path)
- nothing is active at all → not current

`cargo test`: 276 passing. `cargo fmt --check` clean.

## Note for the reviewer

Includes a second commit fixing two **pre-existing** `clippy::for_kv_map` errors at
`update.rs:144` and `:184`, in verbose target-listing loops unrelated to this
change. Current stable clippy errors on them, so CI cannot go green without it —
which also means `main` is currently red on clippy. Two lines, no behavior change.

Also worth knowing: `cargo build` regenerates `src/varlink/*.rs` unformatted via
`build.rs`, so `cargo fmt` has to run *after* a build or those generated files show
up as a 2300-line diff. Not touched here.

## Related

- `avocado-conn`: drops nudges arriving while an update is already in flight.
- `avocado-connect` #706: stops the server re-nudging for rollouts the device can
  never satisfy, which is what generated the nudge storm in the first place.
