### PR TITLE
release: bump version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avocadoctl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avocadoctl"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 # File::try_lock / std::fs::TryLockError (update lock). Both device toolchains
 # clear this: scarthgap via meta-lts-mixins (rust 1.92), wrynose oe-core (1.94).


### PR DESCRIPTION
Version bump for the 0.11.0 release, carrying everything merged since 0.10.0:

- #17 — image_adaptor: stop serving a stale .raw after it is replaced (plus the loop-attachment probe and clippy 1.98 fix)
- #18 — staging: rename the active link into place instead of unlinking first
- #19 — config: make the configured state directories actually take effect
- #20 — update: don't refresh extensions when the runtime is already current
- #22 — verity: carry a dm-verity root hash and refuse to ignore one (phase 1; inert until avocado-cli emits `root_hash`, but `manifest_version > 2` is now refused)

`Cargo.toml` + `Cargo.lock` only, matching the 0.10.0 bump (bcae20e). No dependency changes — the meta-avocado `avocadoctl-crates.inc` stays as is. Binary reports `avocadoctl 0.11.0`.

**Held open for build testing before merge.** Staged consumers: meta-avocado bumps to this branch on `scarthgap` and `wrynose` (draft until this lands and the SRCREV is repointed at `main`).