### PR TITLE
os_update: address GPT partitions by PARTLABEL, use layout offsets only without one

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -799,13 +799,17 @@ dir = "/override/test/path"
         let _guard = ENV_VAR_MUTEX.lock().unwrap();
         let restore = ScopedEnv::clear(&[]);
         std::env::set_var("AVOCADO_TEST_MODE", "1");
-        std::env::set_var("TMPDIR", "/scratch");
+        // A real directory, kept: tests in other modules call TempDir::new()
+        // without ENV_VAR_MUTEX and read TMPDIR while this is set. A path that
+        // does not exist (the old "/scratch") made them fail on NotFound.
+        let scratch = tempfile::tempdir().unwrap().keep();
+        std::env::set_var("TMPDIR", &scratch);
 
         let mut config = Config::default();
         config.avocado.runtimes_dir = Some("/mnt/state/avocado".to_string());
         assert_eq!(
             config.get_os_releases_dir("v1"),
-            "/scratch/avocado/os-releases/v1"
+            format!("{}/avocado/os-releases/v1", scratch.display())
         );
 
         std::env::remove_var("AVOCADO_TEST_MODE");

--- a/src/os_update.rs
+++ b/src/os_update.rs
@@ -587,54 +587,65 @@ fn locate_target(
     partition_name: &str,
     layout: Option<&BundleLayout>,
 ) -> Result<WriteTarget, OsUpdateError> {
-    // Only an ABSENT label may fall back. A label that exists but cannot be
-    // resolved (dangling symlink, EACCES, I/O error) is a real error to surface,
-    // not a reason to start writing by computed offset.
-    let label = PathBuf::from(format!("/dev/disk/by-partlabel/{partition_name}"));
-    if label.exists() {
+    // Only a DEFINITELY ABSENT label may fall back. A label entry that exists
+    // but cannot be resolved (dangling symlink, EACCES, I/O error) is a real
+    // error to surface, not a reason to start writing by computed offset.
+    if !label_absent(partition_name) {
         return resolve_partition(partition_name).map(WriteTarget::Partition);
     }
-    match resolve_partition(partition_name) {
-        Ok(path) => Ok(WriteTarget::Partition(path)),
-        Err(not_found) => match layout {
-            // Offsets are only trusted on a disk that carries no labels at all.
-            // A labeled disk missing this one label is a layout mismatch (a
-            // device provisioned before a partition was added), and writing by
-            // computed offset there would land on whatever lives at that offset
-            // now.
-            Some(layout) if !disk_has_any_label(layout) => Ok(WriteTarget::Offset {
-                device: layout.device.clone(),
-                byte_offset: resolve_partition_offset(partition_name, layout)?,
-            }),
-            Some(_) => Err(OsUpdateError::ArtifactWriteFailed(format!(
-                "Partition '{partition_name}' has no PARTLABEL on this device but its \
-                 neighbours do: the device's partition layout predates this bundle. \
-                 Reprovision to the new layout; an OS update cannot add partitions."
-            ))),
-            None => Err(not_found),
-        },
+    match layout {
+        // Offsets are only trusted on a disk that carries no labels at all.
+        // A labeled disk missing this one label is a layout mismatch (a
+        // device provisioned before a partition was added), and writing by
+        // computed offset there would land on whatever lives at that offset
+        // now.
+        Some(layout) if !disk_has_any_label(layout) => Ok(WriteTarget::Offset {
+            device: layout.device.clone(),
+            byte_offset: resolve_partition_offset(partition_name, layout)?,
+        }),
+        Some(_) => Err(OsUpdateError::ArtifactWriteFailed(format!(
+            "Partition '{partition_name}' has no PARTLABEL on this device but its \
+             neighbours do: the device's partition layout predates this bundle. \
+             Reprovision to the new layout; an OS update cannot add partitions."
+        ))),
+        None => Err(not_found(partition_name)),
     }
 }
 
-/// Whether any partition the bundle's layout names exists by PARTLABEL here -
-/// i.e. the disk is GPT with labels, and offsets are not the way to address it.
+/// Whether `/dev/disk/by-partlabel/<name>` is definitely absent. Only a clean
+/// NotFound counts: `Path::exists()` also says "no" for a dangling symlink or
+/// a metadata error, and treating those as absent would enable raw offset
+/// writes on a disk that is in fact labeled.
+fn label_absent(partition_name: &str) -> bool {
+    matches!(
+        fs::symlink_metadata(format!("/dev/disk/by-partlabel/{partition_name}")),
+        Err(e) if e.kind() == io::ErrorKind::NotFound
+    )
+}
+
+fn not_found(partition_name: &str) -> OsUpdateError {
+    OsUpdateError::ArtifactWriteFailed(format!(
+        "Partition not found: /dev/disk/by-partlabel/{partition_name}"
+    ))
+}
+
+/// Whether any partition the bundle's layout names has a PARTLABEL entry here,
+/// i.e. the disk is GPT with labels and offsets are not the way to address it.
+/// Anything short of a definite NotFound counts as evidence of a label.
 fn disk_has_any_label(layout: &BundleLayout) -> bool {
     layout
         .partitions
         .iter()
         .filter_map(|p| p.name.as_deref())
-        .any(|name| Path::new(&format!("/dev/disk/by-partlabel/{name}")).exists())
+        .any(|name| !label_absent(name))
 }
 
 fn resolve_partition(partition_name: &str) -> Result<PathBuf, OsUpdateError> {
-    let path = PathBuf::from(format!("/dev/disk/by-partlabel/{partition_name}"));
-    if !path.exists() {
-        return Err(OsUpdateError::ArtifactWriteFailed(format!(
-            "Partition not found: /dev/disk/by-partlabel/{partition_name}"
-        )));
+    if label_absent(partition_name) {
+        return Err(not_found(partition_name));
     }
     // Resolve the symlink to get the actual device
-    fs::canonicalize(&path).map_err(|e| {
+    fs::canonicalize(format!("/dev/disk/by-partlabel/{partition_name}")).map_err(|e| {
         OsUpdateError::ArtifactWriteFailed(format!(
             "Failed to resolve partition {partition_name}: {e}"
         ))

--- a/src/os_update.rs
+++ b/src/os_update.rs
@@ -241,23 +241,26 @@ pub fn apply_os_update(
         // Verify SHA256 of source file
         verify_sha256(&source_path, &artifact.sha256, &artifact.name)?;
 
-        // Write to partition: use layout-based offset if available (MBR), else PARTLABEL (GPT)
-        if let Some(ref layout) = bundle.layout {
-            let byte_offset = resolve_partition_offset(&target.partition, layout)?;
-            println!(
-                "    Writing {} -> {}@{} (partition: {})",
-                artifact.name, layout.device, byte_offset, target.partition
-            );
-            write_to_device_at_offset(&source_path, &layout.device, byte_offset, &artifact.name)?;
-        } else {
-            let partition_path = resolve_partition(&target.partition)?;
-            println!(
-                "    Writing {} -> {} (partition: {})",
-                artifact.name,
-                partition_path.display(),
-                target.partition
-            );
-            write_to_partition(&source_path, &partition_path, &artifact.name)?;
+        match locate_target(&target.partition, bundle.layout.as_ref())? {
+            WriteTarget::Partition(partition_path) => {
+                println!(
+                    "    Writing {} -> {} (partition: {})",
+                    artifact.name,
+                    partition_path.display(),
+                    target.partition
+                );
+                write_to_partition(&source_path, &partition_path, &artifact.name)?;
+            }
+            WriteTarget::Offset {
+                device,
+                byte_offset,
+            } => {
+                println!(
+                    "    Writing {} -> {}@{} (partition: {})",
+                    artifact.name, device, byte_offset, target.partition
+                );
+                write_to_device_at_offset(&source_path, &device, byte_offset, &artifact.name)?;
+            }
         }
     }
 
@@ -565,6 +568,55 @@ fn determine_inactive_slot(current: &str, strategy: &str) -> Result<String, OsUp
             ))),
         },
     }
+}
+
+/// Where an artifact for `partition_name` gets written.
+enum WriteTarget {
+    Partition(PathBuf),
+    Offset { device: String, byte_offset: u64 },
+}
+
+/// The kernel's view of the disk wins over the bundle's. A GPT partition is
+/// addressed by its PARTLABEL whenever udev has one for it; the bundle's
+/// `layout` (device path + computed offsets) is only for layouts that carry no
+/// labels (MBR). Preferring the layout when a label exists wrote to the wrong
+/// disk on i.MX: the manifest's devpath names the eMMC as /dev/mmcblk1, the
+/// running kernel enumerates it as /dev/mmcblk2, and the computed offsets need
+/// not match where the flasher actually placed the partitions.
+fn locate_target(
+    partition_name: &str,
+    layout: Option<&BundleLayout>,
+) -> Result<WriteTarget, OsUpdateError> {
+    match resolve_partition(partition_name) {
+        Ok(path) => Ok(WriteTarget::Partition(path)),
+        Err(not_found) => match layout {
+            // Offsets are only trusted on a disk that carries no labels at all.
+            // A labeled disk missing this one label is a layout mismatch (a
+            // device provisioned before a partition was added), and writing by
+            // computed offset there would land on whatever lives at that offset
+            // now.
+            Some(layout) if !disk_has_any_label(layout) => Ok(WriteTarget::Offset {
+                device: layout.device.clone(),
+                byte_offset: resolve_partition_offset(partition_name, layout)?,
+            }),
+            Some(_) => Err(OsUpdateError::ArtifactWriteFailed(format!(
+                "Partition '{partition_name}' has no PARTLABEL on this device but its \
+                 neighbours do: the device's partition layout predates this bundle. \
+                 Reprovision to the new layout; an OS update cannot add partitions."
+            ))),
+            None => Err(not_found),
+        },
+    }
+}
+
+/// Whether any partition the bundle's layout names exists by PARTLABEL here -
+/// i.e. the disk is GPT with labels, and offsets are not the way to address it.
+fn disk_has_any_label(layout: &BundleLayout) -> bool {
+    layout
+        .partitions
+        .iter()
+        .filter_map(|p| p.name.as_deref())
+        .any(|name| Path::new(&format!("/dev/disk/by-partlabel/{name}")).exists())
 }
 
 fn resolve_partition(partition_name: &str) -> Result<PathBuf, OsUpdateError> {
@@ -1418,24 +1470,27 @@ pub fn apply_os_update_streaming<R: Read>(
             artifact.name, target.partition
         );
 
-        // Route to the appropriate write function based on layout (MBR vs GPT)
-        if let Some(ref layout) = bundle.layout {
-            let byte_offset = resolve_partition_offset(&target.partition, layout)?;
-            stream_to_device_at_offset(
-                &mut entry,
-                &layout.device,
+        match locate_target(&target.partition, bundle.layout.as_ref())? {
+            WriteTarget::Partition(partition_path) => {
+                stream_to_partition(
+                    &mut entry,
+                    &partition_path,
+                    &artifact.sha256,
+                    &artifact.name,
+                )?;
+            }
+            WriteTarget::Offset {
+                device,
                 byte_offset,
-                &artifact.sha256,
-                &artifact.name,
-            )?;
-        } else {
-            let partition_path = resolve_partition(&target.partition)?;
-            stream_to_partition(
-                &mut entry,
-                &partition_path,
-                &artifact.sha256,
-                &artifact.name,
-            )?;
+            } => {
+                stream_to_device_at_offset(
+                    &mut entry,
+                    &device,
+                    byte_offset,
+                    &artifact.sha256,
+                    &artifact.name,
+                )?;
+            }
         }
 
         seen.insert(entry_path_str);
@@ -1481,6 +1536,45 @@ pub fn apply_os_update_streaming<R: Read>(
 
 #[cfg(test)]
 mod tests {
+    fn layout_with(name: &str, offset: f64) -> BundleLayout {
+        BundleLayout {
+            device: "/dev/mmcblk1".to_string(),
+            block_size: Some(512),
+            partitions: vec![LayoutPartition {
+                name: Some(name.to_string()),
+                offset: Some(offset),
+                offset_unit: Some("bytes".to_string()),
+                size: 8.0,
+                size_unit: "mebibytes".to_string(),
+                expand: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn an_unlabeled_partition_falls_back_to_the_layout_offset() {
+        // No such PARTLABEL on any test host, so the label lookup fails and the
+        // layout (MBR-style) is the only way to address it.
+        match locate_target(
+            "avocadoctl-test-no-such-label",
+            Some(&layout_with("avocadoctl-test-no-such-label", 4096.0)),
+        ) {
+            Ok(WriteTarget::Offset {
+                device,
+                byte_offset,
+            }) => {
+                assert_eq!(device, "/dev/mmcblk1");
+                assert_eq!(byte_offset, 4096);
+            }
+            other => panic!("expected layout offset, got {:?}", other.map(|_| ())),
+        }
+    }
+
+    #[test]
+    fn an_unlabeled_partition_without_a_layout_is_an_error() {
+        assert!(locate_target("avocadoctl-test-no-such-label", None).is_err());
+    }
+
     use super::*;
     use tempfile::TempDir;
 

--- a/src/os_update.rs
+++ b/src/os_update.rs
@@ -587,6 +587,13 @@ fn locate_target(
     partition_name: &str,
     layout: Option<&BundleLayout>,
 ) -> Result<WriteTarget, OsUpdateError> {
+    // Only an ABSENT label may fall back. A label that exists but cannot be
+    // resolved (dangling symlink, EACCES, I/O error) is a real error to surface,
+    // not a reason to start writing by computed offset.
+    let label = PathBuf::from(format!("/dev/disk/by-partlabel/{partition_name}"));
+    if label.exists() {
+        return resolve_partition(partition_name).map(WriteTarget::Partition);
+    }
     match resolve_partition(partition_name) {
         Ok(path) => Ok(WriteTarget::Partition(path)),
         Err(not_found) => match layout {
@@ -1551,14 +1558,16 @@ mod tests {
         }
     }
 
+    /// A label no attached medium can plausibly carry: the test's own pid makes
+    /// it unique per run, so the lookup fails for the right reason.
+    fn no_such_label() -> String {
+        format!("avocadoctl-test-no-such-label-{}", std::process::id())
+    }
+
     #[test]
     fn an_unlabeled_partition_falls_back_to_the_layout_offset() {
-        // No such PARTLABEL on any test host, so the label lookup fails and the
-        // layout (MBR-style) is the only way to address it.
-        match locate_target(
-            "avocadoctl-test-no-such-label",
-            Some(&layout_with("avocadoctl-test-no-such-label", 4096.0)),
-        ) {
+        let name = no_such_label();
+        match locate_target(&name, Some(&layout_with(&name, 4096.0))) {
             Ok(WriteTarget::Offset {
                 device,
                 byte_offset,
@@ -1572,7 +1581,7 @@ mod tests {
 
     #[test]
     fn an_unlabeled_partition_without_a_layout_is_an_error() {
-        assert!(locate_target("avocadoctl-test-no-such-label", None).is_err());
+        assert!(locate_target(&no_such_label(), None).is_err());
     }
 
     use super::*;


### PR DESCRIPTION
`avocado deploy` to an imx8mp-evk failed in `os_update`:

```
Writing rootfs_hash -> /dev/mmcblk1@618659840 (partition: rootfs-b-hash)
Failed to open device /dev/mmcblk1 for rootfs_hash: No such file or directory
```

## What

When the bundle carries a `layout` (stone always emits one), artifacts were written by raw offset to the layout's device path even though `/dev/disk/by-partlabel/<name>` existed. The manifest's devpath is kernel-dependent (the eMMC is `mmcblk1` in the manifest, `mmcblk2` under 6.18), and computed offsets need not match where fwup placed the partitions.

## How

`locate_target` resolves the PARTLABEL first. The layout offset is used only when the disk carries no labels at all (MBR layouts). A labeled disk that lacks this one label is a layout mismatch — a device provisioned before the partition existed — and is refused with a message saying to reprovision, rather than written at a computed offset onto whatever is there now. Both the staged and the streaming write paths use it.

Tests: unlabeled + layout → offset; unlabeled without layout → error.