### PR TITLE
fix(update): serialise update passes and verify the staged file on disk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "avocadoctl"
 version = "0.10.0"
 edition = "2021"
+# File::try_lock / std::fs::TryLockError (update lock). Both device toolchains
+# clear this: scarthgap via meta-lts-mixins (rust 1.92), wrynose oe-core (1.94).
+rust-version = "1.89"
 description = "Avocado Linux control CLI tool"
 authors = ["Avocado"]
 license = "Apache-2.0"

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -19,6 +19,16 @@ pub struct GcResult {
 /// Keeps at most `retention` runtimes. The active runtime and any runtime
 /// referenced by `pending-update.json` are always kept regardless of the limit.
 pub fn collect_garbage(base_dir: &Path, retention: u32) -> Result<GcResult, StagingError> {
+    // Same lock as `update::perform_update`. Between an update installing its
+    // images and writing the runtime manifest, those images are referenced by
+    // nothing on disk, and `cleanup_orphaned_images` would delete them from
+    // under the pass. The agent calls GC right after an update returns, and a
+    // duplicate "update available" nudge can have a second pass mid-flight by
+    // then. Skip rather than wait: a stuck download must not pin this thread.
+    let _lock = crate::update::acquire_update_lock(base_dir).map_err(|e| match e {
+        crate::update::UpdateError::UpdateInProgress => StagingError::UpdateInProgress,
+        other => StagingError::StagingFailed(other.to_string()),
+    })?;
     let retention = retention.max(1) as usize;
     let mut result = GcResult::default();
 
@@ -218,6 +228,18 @@ mod tests {
             removed.contains(&"orphan.verity".to_string()),
             "an unreferenced hash tree is still garbage, removed: {removed:?}"
         );
+    }
+
+    #[test]
+    fn test_gc_skipped_while_update_holds_the_lock() {
+        let tmp = TempDir::new().unwrap();
+        let held = crate::update::acquire_update_lock(tmp.path()).unwrap();
+        assert!(matches!(
+            collect_garbage(tmp.path(), 3),
+            Err(StagingError::UpdateInProgress)
+        ));
+        drop(held);
+        collect_garbage(tmp.path(), 3).unwrap();
     }
 
     #[test]

--- a/src/service/error.rs
+++ b/src/service/error.rs
@@ -119,6 +119,9 @@ impl From<crate::staging::StagingError> for AvocadoError {
             crate::staging::StagingError::HashMismatch(details) => {
                 AvocadoError::StagingFailed { reason: details }
             }
+            crate::staging::StagingError::UpdateInProgress => AvocadoError::StagingFailed {
+                reason: crate::staging::StagingError::UpdateInProgress.to_string(),
+            },
         }
     }
 }

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -13,6 +13,9 @@ pub enum StagingError {
     #[error("Staging failed: {0}")]
     StagingFailed(String),
 
+    #[error("Another update is in progress; garbage collection skipped")]
+    UpdateInProgress,
+
     #[error("Cannot remove the active runtime. Activate a different runtime first.")]
     RemoveActiveRuntime,
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -25,6 +25,15 @@ pub enum UpdateError {
         actual: String,
     },
 
+    #[error(
+        "Length mismatch for target '{target}': expected {expected} bytes, got {actual} bytes"
+    )]
+    LengthMismatch {
+        target: String,
+        expected: u64,
+        actual: u64,
+    },
+
     #[error("Staging failed: {0}")]
     StagingFailed(String),
 
@@ -465,7 +474,7 @@ pub fn perform_update(
 /// Take an exclusive advisory lock on `<base_dir>/.update.lock` for the lifetime
 /// of the returned handle. Fails fast with `UpdateInProgress` rather than
 /// blocking: the caller (usually the agent) already has its own retry cadence.
-fn acquire_update_lock(base_dir: &Path) -> Result<File, UpdateError> {
+pub(crate) fn acquire_update_lock(base_dir: &Path) -> Result<File, UpdateError> {
     fs::create_dir_all(base_dir)
         .map_err(|e| UpdateError::StagingFailed(format!("Failed to create base dir: {e}")))?;
     let lock = File::create(base_dir.join(".update.lock"))
@@ -701,10 +710,10 @@ fn download_target(
         let data = fetch_url_bytes(&target_url, auth_token)?;
 
         if data.len() as u64 != target_info.length {
-            return Err(UpdateError::HashMismatch {
+            return Err(UpdateError::LengthMismatch {
                 target: name_str.to_string(),
-                expected: format!("{} bytes", target_info.length),
-                actual: format!("{} bytes", data.len()),
+                expected: target_info.length,
+                actual: data.len() as u64,
             });
         }
 
@@ -824,10 +833,10 @@ fn download_target_streaming(
         if on_disk > expected_len {
             let _ = fs::remove_file(&part_path);
         }
-        return Err(UpdateError::HashMismatch {
+        return Err(UpdateError::LengthMismatch {
             target: name.to_string(),
-            expected: format!("{expected_len} bytes"),
-            actual: format!("{on_disk} bytes"),
+            expected: expected_len,
+            actual: on_disk,
         });
     }
 
@@ -851,9 +860,14 @@ fn download_target_streaming(
 }
 
 /// Issue an HTTP GET (optionally with Range header), returning the open file
-/// handle and a body reader. If the server doesn't support Range (returns 200
-/// instead of 206), the file is truncated and download starts from the beginning.
-/// Returns (file, body_reader) and the effective byte offset we're writing from.
+/// handle and a body reader, plus the byte offset the body continues from.
+///
+/// The `.part` is only ever replaced once a full-file response is in hand:
+/// `File::create` truncates it at that point and never before. A ranged request
+/// that fails on transport, or with any status other than 416, leaves the file
+/// untouched — it is still a valid prefix and the next pass resumes it. On a
+/// multi-GB bundle over a flaky link that is the difference between converging
+/// and starting over on every 503.
 fn fetch_streaming(
     url: &str,
     part_path: &Path,
@@ -869,7 +883,11 @@ fn fetch_streaming(
             req = req.header("Range", format!("bytes={from}-"));
         }
         req.call()
-            .map_err(|e| UpdateError::FetchFailed(url.to_string(), e.to_string()))
+    };
+    let fetch_failed = |e: ureq::Error| UpdateError::FetchFailed(url.to_string(), e.to_string());
+    let create_part = || {
+        File::create(part_path)
+            .map_err(|e| UpdateError::StagingFailed(format!("Failed to create .part: {e}")))
     };
 
     if existing_len > 0 {
@@ -893,42 +911,37 @@ fn fetch_streaming(
                         })?;
                     return Ok(((file, response.into_body()), existing_len));
                 }
-                if status == 206 {
-                    // Partial content from the wrong offset: appending would
-                    // corrupt the prefix. Drop it and download from scratch.
-                    let _ = fs::remove_file(part_path);
-                } else {
-                    // 200 or other — server sent the full file; start fresh
-                    let file = File::create(part_path).map_err(|e| {
-                        UpdateError::StagingFailed(format!("Failed to create .part: {e}"))
-                    })?;
-                    return Ok(((file, response.into_body()), 0));
+                if status != 206 {
+                    // 200: the server ignored Range and sent the whole file.
+                    // That is the replacement; truncate and stream it.
+                    return Ok(((create_part()?, response.into_body()), 0));
                 }
+                // 206 from the wrong offset: appending would corrupt the
+                // prefix. Fall through to a fresh un-ranged request; the .part
+                // is only truncated if that request succeeds.
             }
-            Err(_) => {
-                // Request failed (possibly 416) — delete .part and try fresh
-                let _ = fs::remove_file(part_path);
-            }
+            // Our .part is past what the server has: the resume can never
+            // work, so fall through to a fresh request the same way.
+            Err(ureq::Error::StatusCode(416)) => {}
+            // Transport error, 401, 429, 503, ...: nothing wrong with the
+            // .part. Keep it and let the next pass resume.
+            Err(e) => return Err(fetch_failed(e)),
         }
     }
 
-    // Full download from scratch
-    let response = make_request(None)?;
-    let file = File::create(part_path)
-        .map_err(|e| UpdateError::StagingFailed(format!("Failed to create .part: {e}")))?;
-    Ok(((file, response.into_body()), 0))
+    // Full download from scratch. Only now is the .part replaced.
+    let response = make_request(None).map_err(fetch_failed)?;
+    Ok(((create_part()?, response.into_body()), 0))
 }
 
 /// Start offset of a `Content-Range: bytes <start>-<end>/<total>` header.
+/// Range units are case-insensitive (RFC 9110 §14.1).
 fn content_range_start(value: &str) -> Option<u64> {
-    value
-        .trim()
-        .strip_prefix("bytes ")?
-        .split('-')
-        .next()?
-        .trim()
-        .parse()
-        .ok()
+    let (unit, range) = value.trim().split_once(' ')?;
+    if !unit.eq_ignore_ascii_case("bytes") {
+        return None;
+    }
+    range.trim().split('-').next()?.trim().parse().ok()
 }
 
 /// Compute SHA256 hash of a file by streaming, avoiding loading the full file into memory.
@@ -1569,11 +1582,68 @@ mod tests {
         url
     }
 
+    /// Serves `responses` to successive connections and records each request
+    /// head, so a test can assert what was asked (e.g. a `Range` header).
+    fn serve_requests(
+        responses: Vec<(&'static str, &'static str, Vec<u8>)>,
+    ) -> (String, std::sync::Arc<std::sync::Mutex<Vec<String>>>) {
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/t.raw", listener.local_addr().unwrap());
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let record = seen.clone();
+        std::thread::spawn(move || {
+            for (status, headers, body) in responses {
+                let (mut sock, _) = listener.accept().unwrap();
+                let mut req = [0u8; 4096];
+                let n = sock.read(&mut req).unwrap_or(0);
+                record
+                    .lock()
+                    .unwrap()
+                    .push(String::from_utf8_lossy(&req[..n]).into_owned());
+                let head = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\n{headers}Connection: close\r\n\r\n",
+                    body.len()
+                );
+                sock.write_all(head.as_bytes()).unwrap();
+                sock.write_all(&body).unwrap();
+            }
+        });
+        (url, seen)
+    }
+
+    /// The guard must live for the whole pass, not just `acquire_update_lock`.
+    /// Holds a real `perform_update` inside its first network fetch (well past
+    /// the lock) and checks a second pass is refused while it is there.
     #[test]
-    fn test_update_lock_rejects_concurrent_pass() {
+    fn test_update_lock_held_for_the_whole_pass() {
+        use std::net::TcpListener;
+        use std::sync::mpsc;
         let tmp = tempfile::TempDir::new().unwrap();
-        let held = acquire_update_lock(tmp.path()).unwrap();
-        let result = perform_update(
+        let (root_json, _) = make_test_root_json();
+        fs::create_dir_all(tmp.path().join("metadata")).unwrap();
+        fs::write(tmp.path().join("metadata").join("root.json"), root_json).unwrap();
+
+        // Accept the timestamp.json request, then hold the pass there until told
+        // to let go; dropping the socket then fails the fetch and ends the pass.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let (arrived_tx, arrived_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut req = [0u8; 4096];
+            let _ = sock.read(&mut req);
+            arrived_tx.send(()).unwrap();
+            let _ = release_rx.recv();
+        });
+
+        let base = tmp.path().to_path_buf();
+        let first =
+            std::thread::spawn(move || perform_update(&url, &base, None, None, false, false, 0));
+        arrived_rx.recv().unwrap();
+
+        let second = perform_update(
             "http://127.0.0.1:1",
             tmp.path(),
             None,
@@ -1583,12 +1653,19 @@ mod tests {
             0,
         );
         assert!(
-            matches!(result, Err(UpdateError::UpdateInProgress)),
-            "{result:?}"
+            matches!(second, Err(UpdateError::UpdateInProgress)),
+            "a pass mid-flight must hold the lock: {second:?}"
         );
-        drop(held);
-        // Lock released: the pass proceeds far enough to hit the missing trust anchor.
-        let result = perform_update(
+
+        release_tx.send(()).unwrap();
+        let first = first.join().unwrap();
+        assert!(
+            matches!(first, Err(UpdateError::FetchFailed(..))),
+            "{first:?}"
+        );
+
+        // Released with the pass: the next one gets past the lock to its fetch.
+        let third = perform_update(
             "http://127.0.0.1:1",
             tmp.path(),
             None,
@@ -1598,8 +1675,8 @@ mod tests {
             0,
         );
         assert!(
-            matches!(result, Err(UpdateError::NoTrustAnchor)),
-            "{result:?}"
+            matches!(third, Err(UpdateError::FetchFailed(..))),
+            "{third:?}"
         );
     }
 
@@ -1629,7 +1706,7 @@ mod tests {
         );
         let result = download_target_streaming(&url, &dest, 36, &sha256_hex(full), None, false);
         match result {
-            Err(UpdateError::HashMismatch { actual, .. }) => assert_eq!(actual, "40 bytes"),
+            Err(UpdateError::LengthMismatch { actual, .. }) => assert_eq!(actual, 40),
             other => panic!("expected length mismatch from disk, got {other:?}"),
         }
         assert!(!part.exists(), "over-long .part must not be resumed");
@@ -1649,7 +1726,7 @@ mod tests {
         );
         let result = download_target_streaming(&url, &dest, 36, &sha256_hex(full), None, false);
         assert!(
-            matches!(result, Err(UpdateError::HashMismatch { .. })),
+            matches!(result, Err(UpdateError::LengthMismatch { .. })),
             "{result:?}"
         );
         assert_eq!(
@@ -1659,30 +1736,56 @@ mod tests {
         );
     }
 
+    /// A 206 from the wrong offset is never appended: the pass re-requests
+    /// the file un-ranged and replaces the .part only with that response.
     #[test]
-    fn test_206_wrong_offset_discards_part() {
+    fn test_206_wrong_offset_restarts_unranged() {
         let tmp = tempfile::TempDir::new().unwrap();
         let dest = tmp.path().join("t.raw");
         let part = tmp.path().join("t.raw.part");
         let full = b"0123456789abcdefghijklmnopqrstuvwxyz";
         fs::write(&part, &full[..10]).unwrap();
-        // 206 that resumes from 0 instead of 10. Appending it would have
-        // produced a 46-byte file that also passed the old counter check.
-        let url = serve_once(
-            "206 Partial Content",
-            "Content-Range: bytes 0-35/36\r\n",
-            full.to_vec(),
+        let (url, seen) = serve_requests(vec![
+            (
+                "206 Partial Content",
+                "Content-Range: bytes 0-35/36\r\n",
+                full.to_vec(),
+            ),
+            ("200 OK", "", full.to_vec()),
+        ]);
+        download_target_streaming(&url, &dest, 36, &sha256_hex(full), None, false).unwrap();
+        assert_eq!(fs::read(&dest).unwrap(), full);
+        assert!(!part.exists());
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 2, "{seen:?}");
+        let seen: Vec<String> = seen.iter().map(|r| r.to_ascii_lowercase()).collect();
+        assert!(seen[0].contains("range: bytes=10-"), "{}", seen[0]);
+        assert!(
+            !seen[1].contains("range:"),
+            "restart must be un-ranged: {}",
+            seen[1]
         );
+    }
+
+    /// A ranged request that fails for reasons unrelated to the .part (503,
+    /// 429, connection reset, ...) must leave the prefix for the next pass.
+    #[test]
+    fn test_failed_ranged_request_keeps_part() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dest = tmp.path().join("t.raw");
+        let part = tmp.path().join("t.raw.part");
+        let full = b"0123456789abcdefghijklmnopqrstuvwxyz";
+        fs::write(&part, &full[..10]).unwrap();
+        let url = serve_once("503 Service Unavailable", "", b"busy".to_vec());
         let result = download_target_streaming(&url, &dest, 36, &sha256_hex(full), None, false);
-        // The poisoned .part is dropped and a fresh request made; the one-shot
-        // server is gone by then, so that fetch fails — the point is the .part.
         assert!(
             matches!(result, Err(UpdateError::FetchFailed(..))),
             "{result:?}"
         );
-        assert!(
-            !part.exists(),
-            "wrong-offset .part must be discarded, not appended to"
+        assert_eq!(
+            fs::read(&part).unwrap(),
+            &full[..10],
+            "prefix must survive a 503"
         );
     }
 
@@ -1693,6 +1796,8 @@ mod tests {
             Some(2318743016)
         );
         assert_eq!(content_range_start("bytes 0-9/*"), Some(0));
+        // RFC 9110 §14.1: range units are case-insensitive.
+        assert_eq!(content_range_start("Bytes 10-35/36"), Some(10));
         assert_eq!(content_range_start("bytes */36"), None);
         assert_eq!(content_range_start("garbage"), None);
     }

--- a/src/update.rs
+++ b/src/update.rs
@@ -30,6 +30,9 @@ pub enum UpdateError {
 
     #[error("Metadata error: {0}")]
     MetadataError(String),
+
+    #[error("Another update is already in progress")]
+    UpdateInProgress,
 }
 
 /// What a `perform_update` call actually did.
@@ -64,6 +67,14 @@ pub fn perform_update(
     spot_check_bytes: u64,
 ) -> Result<UpdateOutcome, UpdateError> {
     let url = url.trim_end_matches('/');
+
+    // Serialise whole update passes. The agent can re-fire "update available"
+    // (e.g. on reconnect) while a previous pass is still downloading; two passes
+    // sharing one .part file interleave their bytes and both fail with a bogus
+    // hash mismatch, and the loser's cleanup deletes the winner's staging dir.
+    // The lock file lives beside the staging dir, never inside it, so cleanup
+    // cannot unlink the inode we hold.
+    let _lock = acquire_update_lock(base_dir)?;
 
     // 1. Load the local trust anchor
     let root_path = base_dir.join("metadata").join("root.json");
@@ -451,6 +462,23 @@ pub fn perform_update(
     Ok(outcome)
 }
 
+/// Take an exclusive advisory lock on `<base_dir>/.update.lock` for the lifetime
+/// of the returned handle. Fails fast with `UpdateInProgress` rather than
+/// blocking: the caller (usually the agent) already has its own retry cadence.
+fn acquire_update_lock(base_dir: &Path) -> Result<File, UpdateError> {
+    fs::create_dir_all(base_dir)
+        .map_err(|e| UpdateError::StagingFailed(format!("Failed to create base dir: {e}")))?;
+    let lock = File::create(base_dir.join(".update.lock"))
+        .map_err(|e| UpdateError::StagingFailed(format!("Failed to open update lock: {e}")))?;
+    match lock.try_lock() {
+        Ok(()) => Ok(lock),
+        Err(std::fs::TryLockError::WouldBlock) => Err(UpdateError::UpdateInProgress),
+        Err(std::fs::TryLockError::Error(e)) => Err(UpdateError::StagingFailed(format!(
+            "Failed to lock update lock: {e}"
+        ))),
+    }
+}
+
 /// True when nothing about `manifest` requires work: the runtime side is
 /// already active and intact, and the running OS already satisfies the
 /// manifest's os_bundle (if any).
@@ -765,11 +793,10 @@ fn download_target_streaming(
         println!("    Downloading {name} ({expected_len} bytes)...");
     }
 
-    let (mut file, bytes_before) = fetch_streaming(url, &part_path, existing_len, auth_token)?;
+    let (mut file, _bytes_before) = fetch_streaming(url, &part_path, existing_len, auth_token)?;
 
     // 4. Stream response body to disk
     let mut buf = [0u8; 64 * 1024];
-    let mut total = bytes_before;
     let mut reader = file.1.as_reader();
     loop {
         let n = reader
@@ -781,19 +808,26 @@ fn download_target_streaming(
         file.0
             .write_all(&buf[..n])
             .map_err(|e| UpdateError::StagingFailed(format!("Write failed for {name}: {e}")))?;
-        total += n as u64;
     }
     file.0
         .sync_all()
         .map_err(|e| UpdateError::StagingFailed(format!("Sync failed for {name}: {e}")))?;
 
-    // 5. Verify length
-    if total != expected_len {
-        let _ = fs::remove_file(&part_path);
+    // 5. Verify length of the file on disk, not our own byte counter. A short
+    // body is a valid prefix: keep the .part so the next pass resumes it.
+    // Anything longer than expected is corrupt and must not be resumed.
+    let on_disk = part_path
+        .metadata()
+        .map_err(|e| UpdateError::StagingFailed(format!("Failed to stat {name}.part: {e}")))?
+        .len();
+    if on_disk != expected_len {
+        if on_disk > expected_len {
+            let _ = fs::remove_file(&part_path);
+        }
         return Err(UpdateError::HashMismatch {
             target: name.to_string(),
             expected: format!("{expected_len} bytes"),
-            actual: format!("{total} bytes"),
+            actual: format!("{on_disk} bytes"),
         });
     }
 
@@ -842,8 +876,13 @@ fn fetch_streaming(
         match make_request(Some(existing_len)) {
             Ok(response) => {
                 let status = response.status().as_u16();
-                if status == 206 {
-                    // Server supports Range — append to existing .part file
+                let resumed_at = response
+                    .headers()
+                    .get("Content-Range")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(content_range_start);
+                if status == 206 && resumed_at == Some(existing_len) {
+                    // Server resumed exactly where we left off — append.
                     let file = OpenOptions::new()
                         .append(true)
                         .open(part_path)
@@ -854,11 +893,17 @@ fn fetch_streaming(
                         })?;
                     return Ok(((file, response.into_body()), existing_len));
                 }
-                // 200 or other — server sent the full file; start fresh
-                let file = File::create(part_path).map_err(|e| {
-                    UpdateError::StagingFailed(format!("Failed to create .part: {e}"))
-                })?;
-                return Ok(((file, response.into_body()), 0));
+                if status == 206 {
+                    // Partial content from the wrong offset: appending would
+                    // corrupt the prefix. Drop it and download from scratch.
+                    let _ = fs::remove_file(part_path);
+                } else {
+                    // 200 or other — server sent the full file; start fresh
+                    let file = File::create(part_path).map_err(|e| {
+                        UpdateError::StagingFailed(format!("Failed to create .part: {e}"))
+                    })?;
+                    return Ok(((file, response.into_body()), 0));
+                }
             }
             Err(_) => {
                 // Request failed (possibly 416) — delete .part and try fresh
@@ -872,6 +917,18 @@ fn fetch_streaming(
     let file = File::create(part_path)
         .map_err(|e| UpdateError::StagingFailed(format!("Failed to create .part: {e}")))?;
     Ok(((file, response.into_body()), 0))
+}
+
+/// Start offset of a `Content-Range: bytes <start>-<end>/<total>` header.
+fn content_range_start(value: &str) -> Option<u64> {
+    value
+        .trim()
+        .strip_prefix("bytes ")?
+        .split('-')
+        .next()?
+        .trim()
+        .parse()
+        .ok()
 }
 
 /// Compute SHA256 hash of a file by streaming, avoiding loading the full file into memory.
@@ -1478,6 +1535,166 @@ mod tests {
         // Should fail because the URL is unreachable, but the bad file should be gone
         assert!(result.is_err());
         assert!(!dest.exists(), "Bad file should have been removed");
+    }
+
+    /// One-shot HTTP server: answers the first request with `status`, the given
+    /// extra headers and `body`, then exits. Returns the URL to hit.
+    fn serve_once(status: &'static str, headers: &'static str, body: Vec<u8>) -> String {
+        serve_once_then(status, headers, body, || {})
+    }
+
+    /// Like `serve_once`, but runs `on_request` after the request arrives and
+    /// before the body is sent — a hook to act as a concurrent writer.
+    fn serve_once_then(
+        status: &'static str,
+        headers: &'static str,
+        body: Vec<u8>,
+        on_request: impl FnOnce() + Send + 'static,
+    ) -> String {
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/t.raw", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut req = [0u8; 4096];
+            let _ = sock.read(&mut req);
+            on_request();
+            let head = format!(
+                "HTTP/1.1 {status}\r\nContent-Length: {}\r\n{headers}Connection: close\r\n\r\n",
+                body.len()
+            );
+            sock.write_all(head.as_bytes()).unwrap();
+            sock.write_all(&body).unwrap();
+        });
+        url
+    }
+
+    #[test]
+    fn test_update_lock_rejects_concurrent_pass() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let held = acquire_update_lock(tmp.path()).unwrap();
+        let result = perform_update(
+            "http://127.0.0.1:1",
+            tmp.path(),
+            None,
+            None,
+            false,
+            false,
+            0,
+        );
+        assert!(
+            matches!(result, Err(UpdateError::UpdateInProgress)),
+            "{result:?}"
+        );
+        drop(held);
+        // Lock released: the pass proceeds far enough to hit the missing trust anchor.
+        let result = perform_update(
+            "http://127.0.0.1:1",
+            tmp.path(),
+            None,
+            None,
+            false,
+            false,
+            0,
+        );
+        assert!(
+            matches!(result, Err(UpdateError::NoTrustAnchor)),
+            "{result:?}"
+        );
+    }
+
+    #[test]
+    fn test_resume_length_check_uses_file_on_disk() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dest = tmp.path().join("t.raw");
+        let part = tmp.path().join("t.raw.part");
+        let full = b"0123456789abcdefghijklmnopqrstuvwxyz"; // 36 bytes
+        fs::write(&part, &full[..10]).unwrap();
+        // Correct offset and the correct 26 remaining bytes over our socket —
+        // but a second writer appends to the .part while we download. The old
+        // in-process counter saw 36 and passed; only the hash caught it.
+        let racer = part.clone();
+        let url = serve_once_then(
+            "206 Partial Content",
+            "Content-Range: bytes 10-35/36\r\n",
+            full[10..].to_vec(),
+            move || {
+                OpenOptions::new()
+                    .append(true)
+                    .open(racer)
+                    .unwrap()
+                    .write_all(b"XXXX")
+                    .unwrap();
+            },
+        );
+        let result = download_target_streaming(&url, &dest, 36, &sha256_hex(full), None, false);
+        match result {
+            Err(UpdateError::HashMismatch { actual, .. }) => assert_eq!(actual, "40 bytes"),
+            other => panic!("expected length mismatch from disk, got {other:?}"),
+        }
+        assert!(!part.exists(), "over-long .part must not be resumed");
+    }
+
+    #[test]
+    fn test_short_body_keeps_part_for_resume() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dest = tmp.path().join("t.raw");
+        let part = tmp.path().join("t.raw.part");
+        let full = b"0123456789abcdefghijklmnopqrstuvwxyz";
+        fs::write(&part, &full[..10]).unwrap();
+        let url = serve_once(
+            "206 Partial Content",
+            "Content-Range: bytes 10-19/36\r\n",
+            full[10..20].to_vec(),
+        );
+        let result = download_target_streaming(&url, &dest, 36, &sha256_hex(full), None, false);
+        assert!(
+            matches!(result, Err(UpdateError::HashMismatch { .. })),
+            "{result:?}"
+        );
+        assert_eq!(
+            fs::read(&part).unwrap(),
+            &full[..20],
+            "valid prefix must survive"
+        );
+    }
+
+    #[test]
+    fn test_206_wrong_offset_discards_part() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dest = tmp.path().join("t.raw");
+        let part = tmp.path().join("t.raw.part");
+        let full = b"0123456789abcdefghijklmnopqrstuvwxyz";
+        fs::write(&part, &full[..10]).unwrap();
+        // 206 that resumes from 0 instead of 10. Appending it would have
+        // produced a 46-byte file that also passed the old counter check.
+        let url = serve_once(
+            "206 Partial Content",
+            "Content-Range: bytes 0-35/36\r\n",
+            full.to_vec(),
+        );
+        let result = download_target_streaming(&url, &dest, 36, &sha256_hex(full), None, false);
+        // The poisoned .part is dropped and a fresh request made; the one-shot
+        // server is gone by then, so that fetch fails — the point is the .part.
+        assert!(
+            matches!(result, Err(UpdateError::FetchFailed(..))),
+            "{result:?}"
+        );
+        assert!(
+            !part.exists(),
+            "wrong-offset .part must be discarded, not appended to"
+        );
+    }
+
+    #[test]
+    fn test_content_range_start() {
+        assert_eq!(
+            content_range_start("bytes 2318743016-2447994879/2447994880"),
+            Some(2318743016)
+        );
+        assert_eq!(content_range_start("bytes 0-9/*"), Some(0));
+        assert_eq!(content_range_start("bytes */36"), None);
+        assert_eq!(content_range_start("garbage"), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Two `avocadoctl` update passes running concurrently (e.g. the agent re-firing "runtime update available" on reconnect while a previous pass is still downloading) shared one deterministic `.part` file. The second pass trusted its length, opened it with `.append(true)`, and both writers interleaved bytes. Each pass counted exactly `expected_len` bytes over its own socket, so both passed the length check and both failed the full-file hash with a misleading `Hash mismatch`. Whichever failed first also `remove_dir_all`'d the shared staging dir under the other.

## How

- **Process-wide lock.** `perform_update` takes an exclusive `flock` (`std::fs::File::try_lock`) on `<base_dir>/.update.lock` for its whole lifetime. A second pass fails fast with `UpdateInProgress` instead of appending; the calling agent already has a retry cadence. The lock file lives beside `.update-staging/`, not inside it, so staging cleanup can't unlink the locked inode. This also covers `install_images_from_staging`, `stage_manifest`, `finish_update` and `apply_os_update`, which had the same unguarded window.
- **Length from disk.** The post-download check uses `metadata().len()` on the `.part`, not the in-process counter, so a corrupt file reports as the length problem it is. A short body keeps the `.part` (it is a valid prefix) rather than throwing away progress.
- **Content-Range on 206.** A partial response whose start offset isn't the `.part` length is discarded and the download restarts from scratch instead of being appended.

No new dependencies. `File::try_lock` is stable since 1.89; `rust-version = "1.89"` records that, and both device toolchains clear it (scarthgap via meta-lts-mixins rust 1.92, wrynose oe-core rust 1.94).

## Tests

Five new tests in `update::tests`, each confirmed to fail when its guard is reverted:

- `test_update_lock_rejects_concurrent_pass` — held lock → `UpdateInProgress`; released → proceeds.
- `test_resume_length_check_uses_file_on_disk` — a second writer appends during a correct 206 resume; the old counter would have passed.
- `test_short_body_keeps_part_for_resume`
- `test_206_wrong_offset_discards_part`
- `test_content_range_start`

`cargo test`: 326 passed. `cargo clippy --all-targets -D warnings`: clean.

## Review follow-ups (74bc9da)

- The `.part` is never unlinked ahead of a replacement: a ranged request that fails on transport or with any status but 416 keeps it; a 416 or wrong-offset 206 leads to a fresh un-ranged request and the file is truncated only when that succeeds. `Content-Range` unit compared case-insensitively.
- `gc::collect_garbage` takes the same lock (non-blocking, `StagingError::UpdateInProgress`), closing the install-then-stage window against the agent's post-update GC. A single mutation lock for `activate_runtime`/`add_from_manifest`/standalone OS apply is a follow-up.
- Length failures report `UpdateError::LengthMismatch`, not `HashMismatch`.
- Tests: the lock test holds a real pass mid-fetch and fails if the guard is dropped; the wrong-offset test proves the un-ranged restart against a two-request server; new tests for a 503 keeping the `.part` and GC refused under the lock.