### PR TITLE
var-key: enroll, list and remove the operator's recovery keyslot on /var

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod hitl;
 pub mod image_adaptor;
 pub mod root_authority;
 pub mod runtime;
+pub mod var_key;
 
 #[cfg(test)]
 pub(crate) mod test_env {

--- a/src/commands/runtime.rs
+++ b/src/commands/runtime.rs
@@ -285,63 +285,68 @@ fn handle_activate(matches: &ArgMatches, config: &Config, output: &OutputManager
 
     // Check if the target runtime requires a different OS
     if let Some(ref os_bundle) = matched.os_bundle {
-        if let Some(ref expected_id) = os_bundle.os_build_id {
-            let already_matches =
-                crate::os_update::verify_os_release(&crate::os_update::VerifyConfig {
-                    verify_type: "os-release".to_string(),
-                    field: "AVOCADO_OS_BUILD_ID".to_string(),
-                    expected: expected_id.clone(),
-                })
-                .unwrap_or(false);
-            if !crate::os_update::os_bundle_satisfied(os_bundle, base_path) {
-                // OS change required — apply update, mark pending, reboot
-                let aos_path = base_path
-                    .join(IMAGES_DIR_NAME)
-                    .join(format!("{}.raw", os_bundle.image_id));
+        // Not gated on os_build_id: os_bundle_satisfied treats a bundle without
+        // one as not satisfied, and skipping OS handling here entirely is how an
+        // initramfs-only change activated without its bundle ever being applied.
+        let expected_id = os_bundle.os_build_id.as_ref();
+        let already_matches = expected_id.is_some_and(|expected| {
+            crate::os_update::verify_os_release(&crate::os_update::VerifyConfig {
+                verify_type: "os-release".to_string(),
+                field: "AVOCADO_OS_BUILD_ID".to_string(),
+                expected: expected.clone(),
+            })
+            .unwrap_or(false)
+        });
+        if !crate::os_update::os_bundle_satisfied(os_bundle, base_path) {
+            // OS change required — apply update, mark pending, reboot
+            let aos_path = base_path
+                .join(IMAGES_DIR_NAME)
+                .join(format!("{}.raw", os_bundle.image_id));
 
-                if !aos_path.exists() {
-                    output.error(
-                        "Runtime Activate",
-                        &format!("OS bundle image not found: {}", aos_path.display()),
-                    );
-                    std::process::exit(1);
-                }
+            if !aos_path.exists() {
+                output.error(
+                    "Runtime Activate",
+                    &format!("OS bundle image not found: {}", aos_path.display()),
+                );
+                std::process::exit(1);
+            }
 
-                output.step(
+            output.step(
                     "Runtime Activate",
                     &if already_matches {
                         format!(
                             "OS change required: initramfs differs from the active runtime's (target initramfs_build_id={})",
                             os_bundle.initramfs_build_id.as_deref().unwrap_or("-")
                         )
-                    } else {
+                    } else if let Some(expected_id) = expected_id {
                         format!(
                             "OS change required (target AVOCADO_OS_BUILD_ID={})",
                             expected_id
                         )
+                    } else {
+                        "OS change required: the bundle carries no AVOCADO_OS_BUILD_ID to verify the running rootfs against".to_string()
                     },
                 );
 
-                if let Err(e) = crate::os_update::apply_os_update(&aos_path, base_path, false) {
-                    output.error("Runtime Activate", &format!("OS update failed: {e}"));
-                    std::process::exit(1);
-                }
-
-                if let Err(e) = crate::os_update::set_pending_runtime_id(&matched.id, base_path) {
-                    output.error(
-                        "Runtime Activate",
-                        &format!("Failed to set pending runtime: {e}"),
-                    );
-                    std::process::exit(1);
-                }
-
-                output.step(
-                    "Runtime Activate",
-                    "OS update applied. Rebooting to activate new OS...",
-                );
-                let _ = std::process::Command::new("reboot").status();
-                return;
+            if let Err(e) = crate::os_update::apply_os_update(&aos_path, base_path, false) {
+                output.error("Runtime Activate", &format!("OS update failed: {e}"));
+                std::process::exit(1);
             }
+
+            if let Err(e) = crate::os_update::set_pending_runtime_id(&matched.id, base_path) {
+                output.error(
+                    "Runtime Activate",
+                    &format!("Failed to set pending runtime: {e}"),
+                );
+                std::process::exit(1);
+            }
+
+            output.step(
+                "Runtime Activate",
+                "OS update applied. Rebooting to activate new OS...",
+            );
+            let _ = std::process::Command::new("reboot").status();
+            return;
         }
     }
 

--- a/src/commands/runtime.rs
+++ b/src/commands/runtime.rs
@@ -293,8 +293,12 @@ fn handle_activate(matches: &ArgMatches, config: &Config, output: &OutputManager
                     expected: expected_id.clone(),
                 })
                 .unwrap_or(false);
+            let initramfs_changed = crate::service::runtime::initramfs_differs_from_active(
+                os_bundle,
+                crate::service::runtime::active_manifest(base_path).as_ref(),
+            );
 
-            if !already_matches {
+            if !already_matches || initramfs_changed {
                 // OS change required — apply update, mark pending, reboot
                 let aos_path = base_path
                     .join(IMAGES_DIR_NAME)
@@ -310,10 +314,17 @@ fn handle_activate(matches: &ArgMatches, config: &Config, output: &OutputManager
 
                 output.step(
                     "Runtime Activate",
-                    &format!(
-                        "OS change required (target AVOCADO_OS_BUILD_ID={})",
-                        expected_id
-                    ),
+                    &if already_matches {
+                        format!(
+                            "OS change required: initramfs differs from the active runtime's (target initramfs_build_id={})",
+                            os_bundle.initramfs_build_id.as_deref().unwrap_or("-")
+                        )
+                    } else {
+                        format!(
+                            "OS change required (target AVOCADO_OS_BUILD_ID={})",
+                            expected_id
+                        )
+                    },
                 );
 
                 if let Err(e) = crate::os_update::apply_os_update(&aos_path, base_path, false) {

--- a/src/commands/runtime.rs
+++ b/src/commands/runtime.rs
@@ -293,12 +293,7 @@ fn handle_activate(matches: &ArgMatches, config: &Config, output: &OutputManager
                     expected: expected_id.clone(),
                 })
                 .unwrap_or(false);
-            let initramfs_changed = crate::service::runtime::initramfs_differs_from_active(
-                os_bundle,
-                crate::service::runtime::active_manifest(base_path).as_ref(),
-            );
-
-            if !already_matches || initramfs_changed {
+            if !crate::os_update::os_bundle_satisfied(os_bundle, base_path) {
                 // OS change required — apply update, mark pending, reboot
                 let aos_path = base_path
                     .join(IMAGES_DIR_NAME)

--- a/src/commands/var_key.rs
+++ b/src/commands/var_key.rs
@@ -70,9 +70,14 @@ pub fn handle_command(matches: &ArgMatches, output: &OutputManager) {
             let kind = m.get_one::<String>("kind").cloned().unwrap_or_default();
             passphrase.and_then(|p| enroll(&SystemRunner, &p, &kind))
         }
-        Some(("list", _)) => list(&SystemRunner).map(|rows| {
-            for r in rows {
-                println!("{r}");
+        Some(("list", _)) => list(&SystemRunner).map(|(dev, h)| {
+            if output.is_json() {
+                println!("{}", list_json(&dev, &h));
+            } else {
+                println!("device: {dev}");
+                for r in describe(&h) {
+                    println!("{r}");
+                }
             }
             "listed".to_string()
         }),
@@ -125,8 +130,11 @@ impl Runner for SystemRunner {
             .map_err(|e| format!("cannot run cryptsetup: {e}"))?;
         if let Some(data) = stdin {
             let mut pipe = child.stdin.take().expect("piped stdin");
-            pipe.write_all(data)
-                .map_err(|e| format!("cannot feed cryptsetup: {e}"))?;
+            if let Err(e) = pipe.write_all(data) {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("cannot feed cryptsetup: {e}"));
+            }
         }
         let out = child
             .wait_with_output()
@@ -146,11 +154,12 @@ impl Runner for SystemRunner {
         use std::os::unix::fs::OpenOptionsExt;
         let dir = Path::new("/run/avocado");
         fs::create_dir_all(dir).map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
-        let path = dir.join(format!("var-key.{}", std::process::id()));
+        // Random name and O_EXCL: a secret never lands on a path someone else
+        // could have guessed and pre-created as a symlink.
+        let path = dir.join(format!("var-key.{}", uuid::Uuid::new_v4()));
         let mut f = fs::OpenOptions::new()
             .write(true)
-            .create(true)
-            .truncate(true)
+            .create_new(true)
             .mode(0o600)
             .open(&path)
             .map_err(|e| format!("cannot create {}: {e}", path.display()))?;
@@ -230,8 +239,8 @@ fn recovery_token(h: &Header) -> Option<&(u32, String, Vec<u32>)> {
     h.tokens.iter().find(|(_, ty, _)| ty == RECOVERY_TOKEN_TYPE)
 }
 
-fn free_slot(h: &Header) -> u32 {
-    (0..32).find(|n| !h.keyslots.contains(n)).unwrap_or(31)
+fn free_slot(h: &Header) -> Option<u32> {
+    (0..32).find(|n| !h.keyslots.contains(n))
 }
 
 pub fn enroll(r: &dyn Runner, passphrase: &[u8], kind: &str) -> Result<String, String> {
@@ -240,7 +249,9 @@ pub fn enroll(r: &dyn Runner, passphrase: &[u8], kind: &str) -> Result<String, S
     }
     let dev = backing_device(r)?;
     let h = header(r, &dev)?;
-    let slot = free_slot(&h);
+    let slot = free_slot(&h).ok_or_else(|| {
+        "all 32 LUKS keyslots on /var are in use; remove one before enrolling".to_string()
+    })?;
     let keyfile = r.secret_file(passphrase)?;
     let slot_s = slot.to_string();
     let added = r.cryptsetup(
@@ -281,9 +292,12 @@ pub fn enroll(r: &dyn Runner, passphrase: &[u8], kind: &str) -> Result<String, S
             )?;
         }
     }
-    let token = format!(
-        "{{\"type\":\"{RECOVERY_TOKEN_TYPE}\",\"keyslots\":[\"{slot}\"],\"kind\":\"{kind}\"}}"
-    );
+    let token = serde_json::json!({
+        "type": RECOVERY_TOKEN_TYPE,
+        "keyslots": [slot.to_string()],
+        "kind": kind,
+    })
+    .to_string();
     let token_file = r.secret_file(token.as_bytes())?;
     let imported = r.cryptsetup(
         &[
@@ -324,17 +338,21 @@ pub fn remove(r: &dyn Runner) -> Result<String, String> {
     Ok(format!("recovery keyslot {:?} removed from {dev}", slots))
 }
 
+/// Token types that reference `slot`.
+fn unlocks(h: &Header, slot: u32) -> Vec<&str> {
+    h.tokens
+        .iter()
+        .filter(|(_, _, ks)| ks.contains(&slot))
+        .map(|(_, ty, _)| ty.as_str())
+        .collect()
+}
+
 /// One line per keyslot: what unlocks it, from the tokens that reference it.
 pub fn describe(h: &Header) -> Vec<String> {
     h.keyslots
         .iter()
         .map(|s| {
-            let via: Vec<&str> = h
-                .tokens
-                .iter()
-                .filter(|(_, _, ks)| ks.contains(s))
-                .map(|(_, ty, _)| ty.as_str())
-                .collect();
+            let via = unlocks(h, *s);
             let what = if via.is_empty() {
                 "passphrase (Argon2id recovery / derived key)".to_string()
             } else {
@@ -345,12 +363,22 @@ pub fn describe(h: &Header) -> Vec<String> {
         .collect()
 }
 
-pub fn list(r: &dyn Runner) -> Result<Vec<String>, String> {
+pub fn list(r: &dyn Runner) -> Result<(String, Header), String> {
     let dev = backing_device(r)?;
     let h = header(r, &dev)?;
-    let mut rows = vec![format!("device: {dev}")];
-    rows.extend(describe(&h));
-    Ok(rows)
+    Ok((dev, h))
+}
+
+/// Machine-readable form of `list`.
+pub fn list_json(dev: &str, h: &Header) -> serde_json::Value {
+    serde_json::json!({
+        "device": dev,
+        "keyslots": h
+            .keyslots
+            .iter()
+            .map(|s| serde_json::json!({ "slot": s, "unlocked_by": unlocks(h, *s) }))
+            .collect::<Vec<_>>(),
+    })
 }
 
 #[cfg(test)]
@@ -407,8 +435,13 @@ mod tests {
                 (1, "avocado-recovery".into(), vec![2])
             ]
         );
-        assert_eq!(free_slot(&h), 3);
+        assert_eq!(free_slot(&h), Some(3));
         assert_eq!(describe(&h)[2], "slot 2: avocado-recovery");
+        let full = Header {
+            keyslots: (0..32).collect(),
+            tokens: vec![],
+        };
+        assert_eq!(free_slot(&full), None);
     }
 
     #[test]

--- a/src/commands/var_key.rs
+++ b/src/commands/var_key.rs
@@ -236,7 +236,17 @@ fn header(r: &dyn Runner, dev: &str) -> Result<Header, String> {
 }
 
 fn recovery_token(h: &Header) -> Option<&(u32, String, Vec<u32>)> {
-    h.tokens.iter().find(|(_, ty, _)| ty == RECOVERY_TOKEN_TYPE)
+    recovery_tokens(h).next()
+}
+
+/// Every recovery token on the device, not just the first.
+///
+/// A retirement that failed half way can leave two, and revoking only one would
+/// report success while the other credential still opens /var.
+fn recovery_tokens(h: &Header) -> impl Iterator<Item = &(u32, String, Vec<u32>)> {
+    h.tokens
+        .iter()
+        .filter(|(_, ty, _)| ty == RECOVERY_TOKEN_TYPE)
 }
 
 fn free_slot(h: &Header) -> Option<u32> {
@@ -279,27 +289,42 @@ pub fn enroll(r: &dyn Runner, passphrase: &[u8], kind: &str) -> Result<String, S
         )
     })?;
 
-    let token = serde_json::json!({
-        "type": RECOVERY_TOKEN_TYPE,
-        "keyslots": [slot.to_string()],
-        "kind": kind,
-    })
-    .to_string();
-    let token_file = r.secret_file(token.as_bytes())?;
-    let imported = r.cryptsetup(
-        &[
-            "token",
-            "import",
-            "--json-file",
-            token_file.to_str().unwrap_or_default(),
-            &dev,
-        ],
-        None,
-    );
-    let _ = fs::remove_file(&token_file);
-    if let Err(e) = imported {
-        let _ = r.cryptsetup(&["luksKillSlot", "--batch-mode", &dev, &slot_s], None);
-        return Err(format!("{e}; keyslot {slot} removed again"));
+    // The keyslot is live from here on, so every failure below has to go through
+    // the same rollback - including the token file, which used to return early
+    // and leave a usable keyslot with nothing identifying it.
+    let tag = || -> Result<(), String> {
+        let token = serde_json::json!({
+            "type": RECOVERY_TOKEN_TYPE,
+            "keyslots": [slot.to_string()],
+            "kind": kind,
+        })
+        .to_string();
+        let token_file = r.secret_file(token.as_bytes())?;
+        let imported = r.cryptsetup(
+            &[
+                "token",
+                "import",
+                "--json-file",
+                token_file.to_str().unwrap_or_default(),
+                &dev,
+            ],
+            None,
+        );
+        let _ = fs::remove_file(&token_file);
+        imported.map(|_| ())
+    };
+    if let Err(e) = tag() {
+        // Report what the rollback actually achieved: claiming the slot was
+        // "removed again" when the kill failed would describe a device that
+        // still has a live, untagged recovery key as unchanged.
+        return Err(
+            match r.cryptsetup(&["luksKillSlot", "--batch-mode", &dev, &slot_s], None) {
+                Ok(_) => format!("{e}; keyslot {slot} removed again"),
+                Err(kill) => format!(
+                    "{e}; and keyslot {slot} could NOT be removed ({kill}): it is live on {dev} with no token identifying it - kill it by hand before treating this device as unchanged"
+                ),
+            },
+        );
     }
 
     // Retire the previous recovery slot only once the new token is on disk: a
@@ -338,20 +363,52 @@ pub fn enroll(r: &dyn Runner, passphrase: &[u8], kind: &str) -> Result<String, S
 pub fn remove(r: &dyn Runner) -> Result<String, String> {
     let dev = backing_device(r)?;
     let h = header(r, &dev)?;
-    let (tid, _, slots) = recovery_token(&h)
-        .cloned()
-        .ok_or_else(|| "no recovery keyslot on /var".to_string())?;
-    r.cryptsetup(
-        &["token", "remove", "--token-id", &tid.to_string(), &dev],
-        None,
-    )?;
-    for s in &slots {
-        r.cryptsetup(
-            &["luksKillSlot", "--batch-mode", &dev, &s.to_string()],
-            None,
-        )?;
+    let tokens: Vec<_> = recovery_tokens(&h).cloned().collect();
+    if tokens.is_empty() {
+        return Err("no recovery keyslot on /var".to_string());
     }
-    Ok(format!("recovery keyslot {:?} removed from {dev}", slots))
+
+    // Kill the keyslot before dropping the token that names it. The keyslot is
+    // the credential; the token is only how a later run finds it again. Removing
+    // metadata first means a failed kill leaves a key that still opens /var and
+    // nothing left to identify it by.
+    let mut killed = Vec::new();
+    let mut live = Vec::new();
+    for (tid, _, slots) in &tokens {
+        let mut all_gone = true;
+        for s in slots {
+            match r.cryptsetup(
+                &["luksKillSlot", "--batch-mode", &dev, &s.to_string()],
+                None,
+            ) {
+                Ok(_) => killed.push(*s),
+                Err(e) => {
+                    all_gone = false;
+                    live.push(format!("{s} ({e})"));
+                }
+            }
+        }
+        // Only drop the token once every keyslot it names is gone, so a device
+        // with a surviving key keeps the token that identifies it.
+        if all_gone {
+            if let Err(e) = r.cryptsetup(
+                &["token", "remove", "--token-id", &tid.to_string(), &dev],
+                None,
+            ) {
+                live.push(format!("token {tid} ({e})"));
+            }
+        }
+    }
+
+    if !live.is_empty() {
+        return Err(format!(
+            "recovery keyslot(s) {} still open {dev}: {}. Removed: {:?}. Revoke the rest before treating this device's recovery key as retired.",
+            live.len(),
+            live.join(", "),
+            killed
+        ));
+    }
+    Ok(format!("recovery keyslot {killed:?} removed from {dev}"))
 }
 
 /// Token types that reference `slot`.
@@ -410,6 +467,10 @@ mod tests {
         calls: RefCell<Vec<String>>,
         fail_import: bool,
         fail_retire: bool,
+        fail_kill: bool,
+        /// Fail `secret_file` from this call onward (1 = the keyfile, 2 = the
+        /// token file, which is the first failure that leaves a live keyslot).
+        fail_secret_file_from: usize,
     }
     impl Fake {
         fn new(dump: &'static str) -> Self {
@@ -418,6 +479,8 @@ mod tests {
                 calls: RefCell::new(vec![]),
                 fail_import: false,
                 fail_retire: false,
+                fail_kill: false,
+                fail_secret_file_from: 0,
             }
         }
     }
@@ -429,10 +492,22 @@ mod tests {
                 "luksDump" => Ok(self.dump.into()),
                 "token" if args[1] == "import" && self.fail_import => Err("token import failed".into()),
                 "token" if args[1] == "remove" && self.fail_retire => Err("token remove failed".into()),
+                "luksKillSlot" if self.fail_kill => Err("device busy".into()),
                 _ => Ok(String::new()),
             }
         }
         fn secret_file(&self, content: &[u8]) -> Result<PathBuf, String> {
+            let nth = self
+                .calls
+                .borrow()
+                .iter()
+                .filter(|c| c.starts_with("secret_file"))
+                .count()
+                + 1;
+            self.calls.borrow_mut().push(format!("secret_file #{nth}"));
+            if self.fail_secret_file_from != 0 && nth >= self.fail_secret_file_from {
+                return Err("no space left on /run".to_string());
+            }
             let p = std::env::temp_dir().join(format!(
                 "avocadoctl-varkey-test-{}-{}",
                 std::process::id(),
@@ -517,6 +592,82 @@ mod tests {
         assert!(
             calls.iter().any(|c| c.contains("--new-key-slot 3 ")),
             "{calls:?}"
+        );
+    }
+
+    const DUMP_TWO_RECOVERY: &str = "Keyslots:\n  0: luks2\n  1: luks2\n  2: luks2\n  3: luks2\nTokens:\n  0: avocado-hwkey\n\tKeyslot:    1\n  1: avocado-recovery\n\tKeyslot:    2\n  2: avocado-recovery\n\tKeyslot:    3\nDigests:\n  0: pbkdf2\n";
+
+    #[test]
+    fn remove_revokes_every_recovery_slot_killing_before_untagging() {
+        // A retirement that failed half way leaves two recovery tokens; removing
+        // only the first would report success while the other still opens /var.
+        let f = Fake::new(DUMP_TWO_RECOVERY);
+        let msg = remove(&f).unwrap();
+        let calls = f.calls.borrow();
+        for slot in ["2", "3"] {
+            let kill = calls
+                .iter()
+                .position(|c| c == &format!("luksKillSlot --batch-mode /dev/mmcblk2p9 {slot}"))
+                .unwrap_or_else(|| panic!("slot {slot} not killed: {calls:?}"));
+            let tid = if slot == "2" { "1" } else { "2" };
+            let token = calls
+                .iter()
+                .position(|c| c.starts_with(&format!("token remove --token-id {tid} ")))
+                .unwrap_or_else(|| panic!("token {tid} not removed: {calls:?}"));
+            // The keyslot is the credential; the token is only how it is found
+            // again, so it must outlive a failed kill.
+            assert!(
+                kill < token,
+                "untagged before killing slot {slot}: {calls:?}"
+            );
+        }
+        assert!(msg.contains('2') && msg.contains('3'), "{msg}");
+    }
+
+    #[test]
+    fn a_failed_kill_keeps_the_token_and_fails_closed() {
+        let mut f = Fake::new(DUMP_WITH_RECOVERY);
+        f.fail_kill = true;
+        let err = remove(&f).unwrap_err();
+        assert!(err.contains("still open"), "{err}");
+        assert!(err.contains("device busy"), "{err}");
+        let calls = f.calls.borrow();
+        assert!(
+            !calls.iter().any(|c| c.starts_with("token remove")),
+            "the token identifying a still-live keyslot was removed: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn a_failure_after_the_key_is_added_rolls_the_keyslot_back() {
+        // Writing the token file used to return early with `?`, leaving a live
+        // keyslot that no token identified.
+        let mut f = Fake::new(DUMP);
+        f.fail_secret_file_from = 2;
+        let err = enroll(&f, b"secret", "hmac-sha256-uid").unwrap_err();
+        assert!(err.contains("no space left"), "{err}");
+        assert!(err.contains("removed again"), "{err}");
+        assert!(
+            f.calls
+                .borrow()
+                .iter()
+                .any(|c| c == "luksKillSlot --batch-mode /dev/mmcblk2p9 2"),
+            "the added keyslot was not rolled back: {:?}",
+            f.calls.borrow()
+        );
+    }
+
+    #[test]
+    fn a_rollback_that_fails_says_the_keyslot_is_still_live() {
+        let mut f = Fake::new(DUMP);
+        f.fail_secret_file_from = 2;
+        f.fail_kill = true;
+        let err = enroll(&f, b"secret", "hmac-sha256-uid").unwrap_err();
+        assert!(err.contains("could NOT be removed"), "{err}");
+        assert!(err.contains("kill it by hand"), "{err}");
+        assert!(
+            !err.contains("removed again"),
+            "reported a rollback that did not happen: {err}"
         );
     }
 

--- a/src/commands/var_key.rs
+++ b/src/commands/var_key.rs
@@ -306,15 +306,28 @@ pub fn enroll(r: &dyn Runner, passphrase: &[u8], kind: &str) -> Result<String, S
     // failed import above must leave the existing recovery path usable, not
     // strip the device of every recovery slot it had.
     if let Some((tid, _, slots)) = recovery_token(&h).cloned() {
-        r.cryptsetup(
-            &["token", "remove", "--token-id", &tid.to_string(), &dev],
-            None,
-        )?;
-        for s in slots {
-            r.cryptsetup(
-                &["luksKillSlot", "--batch-mode", &dev, &s.to_string()],
+        let retired = r
+            .cryptsetup(
+                &["token", "remove", "--token-id", &tid.to_string(), &dev],
                 None,
-            )?;
+            )
+            .and_then(|_| {
+                slots.iter().try_for_each(|s| {
+                    r.cryptsetup(
+                        &["luksKillSlot", "--batch-mode", &dev, &s.to_string()],
+                        None,
+                    )
+                    .map(|_| ())
+                })
+            });
+        // Enrolment already succeeded here, so say so: the failure is that the
+        // OLD key still opens /var. Reporting a bare error invites a retry,
+        // which would add a third slot rather than retire the stale one.
+        if let Err(e) = retired {
+            return Err(format!(
+                "recovery keyslot {slot} is enrolled on {dev} ({kind}), but the previous recovery keyslot(s) {slots:?} could not be retired: {e}. \
+                 The old recovery key still opens this device - remove those keyslots before treating it as revoked. Re-running enroll would add another slot, not fix this."
+            ));
         }
     }
     Ok(format!(
@@ -396,6 +409,7 @@ mod tests {
         dump: &'static str,
         calls: RefCell<Vec<String>>,
         fail_import: bool,
+        fail_retire: bool,
     }
     impl Fake {
         fn new(dump: &'static str) -> Self {
@@ -403,6 +417,7 @@ mod tests {
                 dump,
                 calls: RefCell::new(vec![]),
                 fail_import: false,
+                fail_retire: false,
             }
         }
     }
@@ -413,6 +428,7 @@ mod tests {
                 "status" => Ok("/dev/mapper/var is active and is in use.\n  type:    LUKS2\n  device:  /dev/mmcblk2p9\n".into()),
                 "luksDump" => Ok(self.dump.into()),
                 "token" if args[1] == "import" && self.fail_import => Err("token import failed".into()),
+                "token" if args[1] == "remove" && self.fail_retire => Err("token remove failed".into()),
                 _ => Ok(String::new()),
             }
         }
@@ -500,6 +516,25 @@ mod tests {
         );
         assert!(
             calls.iter().any(|c| c.contains("--new-key-slot 3 ")),
+            "{calls:?}"
+        );
+    }
+
+    #[test]
+    fn a_failed_retire_reports_that_the_new_slot_is_already_enrolled() {
+        // The new slot and token are live by this point; a bare error would
+        // invite a retry that adds a third slot instead of retiring the stale one.
+        let mut f = Fake::new(DUMP_WITH_RECOVERY);
+        f.fail_retire = true;
+        let err = enroll(&f, b"secret", "hmac-sha256-uid").unwrap_err();
+        assert!(err.contains("keyslot 3 is enrolled"), "{err}");
+        assert!(err.contains("still opens this device"), "{err}");
+        // The enrolled slot must not be rolled back - only import failure does that.
+        let calls = f.calls.borrow();
+        assert!(
+            !calls
+                .iter()
+                .any(|c| c == "luksKillSlot --batch-mode /dev/mmcblk2p9 3"),
             "{calls:?}"
         );
     }

--- a/src/commands/var_key.rs
+++ b/src/commands/var_key.rs
@@ -1,0 +1,490 @@
+//! `avocadoctl var-key`: manage the recovery keyslot of the encrypted /var.
+//!
+//! The /var LUKS2 container is opened in the initramfs (cryptsetup-var) from a
+//! hardware-bound keyslot (CAAM, TPM2) or the Argon2id fallback; none of those
+//! passphrases are reachable from the running system, so keyslot changes here
+//! are authorised with the *volume key* that cryptsetup-var linked into the
+//! root user keyring at open time (`--link-vk-to-keyring`). Nothing this
+//! command adds is stored on the device: the operator (avocado-cli) derives the
+//! recovery passphrase for this unit and pipes it in; the header only records
+//! that a recovery slot exists, as an `avocado-recovery` token.
+use crate::output::OutputManager;
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command as Proc, Stdio};
+
+/// Kernel key the initramfs links the volume key under (cryptsetup-var.sh).
+pub const VOLUME_KEY_KEYRING: &str = "%user:cryptsetup:var";
+pub const RECOVERY_TOKEN_TYPE: &str = "avocado-recovery";
+const MAP_NAME: &str = "var";
+
+pub fn create_command() -> Command {
+    Command::new("var-key")
+        .about("Manage the recovery keyslot of the encrypted /var")
+        .subcommand_required(true)
+        .subcommand(
+            Command::new("enroll")
+                .about("Add a recovery keyslot from a passphrase on stdin (or --key-file); replaces an existing one")
+                .arg(
+                    Arg::new("key-file")
+                        .long("key-file")
+                        .value_name("FILE")
+                        .help("Read the passphrase from FILE instead of stdin"),
+                )
+                .arg(
+                    Arg::new("kind")
+                        .long("kind")
+                        .value_name("KIND")
+                        .default_value("hmac-sha256-uid")
+                        .help("How the passphrase was derived, recorded in the token for the operator's benefit"),
+                ),
+        )
+        .subcommand(Command::new("list").about("Show the /var keyslots and what unlocks them"))
+        .subcommand(
+            Command::new("remove")
+                .about("Remove the recovery keyslot")
+                .arg(
+                    Arg::new("yes")
+                        .long("yes")
+                        .action(ArgAction::SetTrue)
+                        .help("Required: confirms the recovery slot is to be removed"),
+                ),
+        )
+}
+
+pub fn handle_command(matches: &ArgMatches, output: &OutputManager) {
+    let result = match matches.subcommand() {
+        Some(("enroll", m)) => {
+            let passphrase = match m.get_one::<String>("key-file") {
+                Some(f) => fs::read(f).map_err(|e| format!("cannot read {f}: {e}")),
+                None => {
+                    let mut buf = Vec::new();
+                    std::io::stdin()
+                        .read_to_end(&mut buf)
+                        .map(|_| buf)
+                        .map_err(|e| format!("cannot read passphrase from stdin: {e}"))
+                }
+            };
+            let kind = m.get_one::<String>("kind").cloned().unwrap_or_default();
+            passphrase.and_then(|p| enroll(&SystemRunner, &p, &kind))
+        }
+        Some(("list", _)) => list(&SystemRunner).map(|rows| {
+            for r in rows {
+                println!("{r}");
+            }
+            "listed".to_string()
+        }),
+        Some(("remove", m)) => {
+            if !m.get_flag("yes") {
+                Err("refusing without --yes: removing the recovery slot leaves /var recoverable only through the hardware keyslot".to_string())
+            } else {
+                remove(&SystemRunner)
+            }
+        }
+        _ => Err("unknown var-key subcommand".to_string()),
+    };
+    match result {
+        Ok(msg) => output.success("var-key", &msg),
+        Err(e) => {
+            output.error("var-key", &e);
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Everything that touches the system goes through here so the logic is
+/// testable against recorded outputs.
+pub trait Runner {
+    /// Run `cryptsetup <args>`, feeding `stdin` if given; Ok(stdout) on exit 0.
+    fn cryptsetup(&self, args: &[&str], stdin: Option<&[u8]>) -> Result<String, String>;
+    /// Write `content` to a private temp file and return its path.
+    fn secret_file(&self, content: &[u8]) -> Result<PathBuf, String>;
+}
+
+pub struct SystemRunner;
+
+impl Runner for SystemRunner {
+    fn cryptsetup(&self, args: &[&str], stdin: Option<&[u8]>) -> Result<String, String> {
+        let mut cmd = Proc::new("cryptsetup");
+        cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+        cmd.stdin(if stdin.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        });
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("cannot run cryptsetup: {e}"))?;
+        if let Some(data) = stdin {
+            let mut pipe = child.stdin.take().expect("piped stdin");
+            pipe.write_all(data)
+                .map_err(|e| format!("cannot feed cryptsetup: {e}"))?;
+        }
+        let out = child
+            .wait_with_output()
+            .map_err(|e| format!("cryptsetup failed: {e}"))?;
+        if out.status.success() {
+            Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+        } else {
+            Err(format!(
+                "cryptsetup {} failed: {}",
+                args.first().copied().unwrap_or(""),
+                String::from_utf8_lossy(&out.stderr).trim()
+            ))
+        }
+    }
+
+    fn secret_file(&self, content: &[u8]) -> Result<PathBuf, String> {
+        use std::os::unix::fs::OpenOptionsExt;
+        let dir = Path::new("/run/avocado");
+        fs::create_dir_all(dir).map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
+        let path = dir.join(format!("var-key.{}", std::process::id()));
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| format!("cannot create {}: {e}", path.display()))?;
+        f.write_all(content)
+            .map_err(|e| format!("cannot write {}: {e}", path.display()))?;
+        Ok(path)
+    }
+}
+
+/// The partition under /dev/mapper/var, from `cryptsetup status`.
+pub fn backing_device(r: &dyn Runner) -> Result<String, String> {
+    let status = r.cryptsetup(&["status", MAP_NAME], None).map_err(|_| {
+        "/var is not an open LUKS mapping (is this image built with var.encrypt?)".to_string()
+    })?;
+    status
+        .lines()
+        .find_map(|l| {
+            l.trim()
+                .strip_prefix("device:")
+                .map(|d| d.trim().to_string())
+        })
+        .filter(|d| !d.is_empty())
+        .ok_or_else(|| "cryptsetup status did not report a backing device".to_string())
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct Header {
+    pub keyslots: Vec<u32>,
+    /// (token id, type, keyslots the token references)
+    pub tokens: Vec<(u32, String, Vec<u32>)>,
+}
+
+/// Parse the Keyslots/Tokens sections of `cryptsetup luksDump`.
+pub fn parse_dump(dump: &str) -> Header {
+    let mut h = Header::default();
+    let mut section = "";
+    for line in dump.lines() {
+        if !line.starts_with([' ', '\t']) {
+            section = line.trim_end_matches(':');
+            continue;
+        }
+        let t = line.trim();
+        match section {
+            "Keyslots" => {
+                if let Some((id, rest)) = t.split_once(':') {
+                    if rest.trim().starts_with("luks") {
+                        if let Ok(n) = id.trim().parse() {
+                            h.keyslots.push(n);
+                        }
+                    }
+                }
+            }
+            "Tokens" => {
+                if line.starts_with("  ") && !line.starts_with('\t') {
+                    if let Some((id, ty)) = t.split_once(':') {
+                        if let Ok(n) = id.trim().parse() {
+                            h.tokens.push((n, ty.trim().to_string(), Vec::new()));
+                        }
+                    }
+                } else if let Some(ks) = t.strip_prefix("Keyslot:") {
+                    if let (Some(last), Ok(n)) = (h.tokens.last_mut(), ks.trim().parse()) {
+                        last.2.push(n);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    h
+}
+
+fn header(r: &dyn Runner, dev: &str) -> Result<Header, String> {
+    Ok(parse_dump(&r.cryptsetup(&["luksDump", dev], None)?))
+}
+
+fn recovery_token(h: &Header) -> Option<&(u32, String, Vec<u32>)> {
+    h.tokens.iter().find(|(_, ty, _)| ty == RECOVERY_TOKEN_TYPE)
+}
+
+fn free_slot(h: &Header) -> u32 {
+    (0..32).find(|n| !h.keyslots.contains(n)).unwrap_or(31)
+}
+
+pub fn enroll(r: &dyn Runner, passphrase: &[u8], kind: &str) -> Result<String, String> {
+    if passphrase.is_empty() {
+        return Err("empty passphrase".to_string());
+    }
+    let dev = backing_device(r)?;
+    let h = header(r, &dev)?;
+    let slot = free_slot(&h);
+    let keyfile = r.secret_file(passphrase)?;
+    let slot_s = slot.to_string();
+    let added = r.cryptsetup(
+        &[
+            "luksAddKey",
+            "--volume-key-keyring",
+            VOLUME_KEY_KEYRING,
+            "--new-keyfile",
+            keyfile.to_str().unwrap_or_default(),
+            "--new-key-slot",
+            &slot_s,
+            "--pbkdf",
+            "pbkdf2",
+            "--pbkdf-force-iterations",
+            "1000",
+            "--batch-mode",
+            &dev,
+        ],
+        None,
+    );
+    let _ = fs::remove_file(&keyfile);
+    added.map_err(|e| {
+        format!(
+            "{e} (was /var opened by cryptsetup-var with the volume key linked to the keyring?)"
+        )
+    })?;
+
+    // Replace a previous recovery slot only once the new one is in place.
+    if let Some((tid, _, slots)) = recovery_token(&h).cloned() {
+        r.cryptsetup(
+            &["token", "remove", "--token-id", &tid.to_string(), &dev],
+            None,
+        )?;
+        for s in slots {
+            r.cryptsetup(
+                &["luksKillSlot", "--batch-mode", &dev, &s.to_string()],
+                None,
+            )?;
+        }
+    }
+    let token = format!(
+        "{{\"type\":\"{RECOVERY_TOKEN_TYPE}\",\"keyslots\":[\"{slot}\"],\"kind\":\"{kind}\"}}"
+    );
+    let token_file = r.secret_file(token.as_bytes())?;
+    let imported = r.cryptsetup(
+        &[
+            "token",
+            "import",
+            "--json-file",
+            token_file.to_str().unwrap_or_default(),
+            &dev,
+        ],
+        None,
+    );
+    let _ = fs::remove_file(&token_file);
+    if let Err(e) = imported {
+        let _ = r.cryptsetup(&["luksKillSlot", "--batch-mode", &dev, &slot_s], None);
+        return Err(format!("{e}; keyslot {slot} removed again"));
+    }
+    Ok(format!(
+        "recovery keyslot {slot} enrolled on {dev} ({kind})"
+    ))
+}
+
+pub fn remove(r: &dyn Runner) -> Result<String, String> {
+    let dev = backing_device(r)?;
+    let h = header(r, &dev)?;
+    let (tid, _, slots) = recovery_token(&h)
+        .cloned()
+        .ok_or_else(|| "no recovery keyslot on /var".to_string())?;
+    r.cryptsetup(
+        &["token", "remove", "--token-id", &tid.to_string(), &dev],
+        None,
+    )?;
+    for s in &slots {
+        r.cryptsetup(
+            &["luksKillSlot", "--batch-mode", &dev, &s.to_string()],
+            None,
+        )?;
+    }
+    Ok(format!("recovery keyslot {:?} removed from {dev}", slots))
+}
+
+/// One line per keyslot: what unlocks it, from the tokens that reference it.
+pub fn describe(h: &Header) -> Vec<String> {
+    h.keyslots
+        .iter()
+        .map(|s| {
+            let via: Vec<&str> = h
+                .tokens
+                .iter()
+                .filter(|(_, _, ks)| ks.contains(s))
+                .map(|(_, ty, _)| ty.as_str())
+                .collect();
+            let what = if via.is_empty() {
+                "passphrase (Argon2id recovery / derived key)".to_string()
+            } else {
+                via.join(", ")
+            };
+            format!("slot {s}: {what}")
+        })
+        .collect()
+}
+
+pub fn list(r: &dyn Runner) -> Result<Vec<String>, String> {
+    let dev = backing_device(r)?;
+    let h = header(r, &dev)?;
+    let mut rows = vec![format!("device: {dev}")];
+    rows.extend(describe(&h));
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    const DUMP: &str = "LUKS header information\nVersion:       \t2\n\nKeyslots:\n  0: luks2\n\tKey:        512 bits\n  1: luks2\n\tKey:        512 bits\nTokens:\n  0: avocado-hwkey\n\tKeyslot:    1\nDigests:\n  0: pbkdf2\n";
+    const DUMP_WITH_RECOVERY: &str = "Keyslots:\n  0: luks2\n  1: luks2\n  2: luks2\nTokens:\n  0: avocado-hwkey\n\tKeyslot:    1\n  1: avocado-recovery\n\tKeyslot:    2\nDigests:\n  0: pbkdf2\n";
+
+    struct Fake {
+        dump: &'static str,
+        calls: RefCell<Vec<String>>,
+        fail_import: bool,
+    }
+    impl Fake {
+        fn new(dump: &'static str) -> Self {
+            Fake {
+                dump,
+                calls: RefCell::new(vec![]),
+                fail_import: false,
+            }
+        }
+    }
+    impl Runner for Fake {
+        fn cryptsetup(&self, args: &[&str], _stdin: Option<&[u8]>) -> Result<String, String> {
+            self.calls.borrow_mut().push(args.join(" "));
+            match args[0] {
+                "status" => Ok("/dev/mapper/var is active and is in use.\n  type:    LUKS2\n  device:  /dev/mmcblk2p9\n".into()),
+                "luksDump" => Ok(self.dump.into()),
+                "token" if args[1] == "import" && self.fail_import => Err("token import failed".into()),
+                _ => Ok(String::new()),
+            }
+        }
+        fn secret_file(&self, content: &[u8]) -> Result<PathBuf, String> {
+            let p = std::env::temp_dir().join(format!(
+                "avocadoctl-varkey-test-{}-{}",
+                std::process::id(),
+                self.calls.borrow().len()
+            ));
+            fs::write(&p, content).unwrap();
+            Ok(p)
+        }
+    }
+
+    #[test]
+    fn parses_keyslots_and_tokens() {
+        let h = parse_dump(DUMP_WITH_RECOVERY);
+        assert_eq!(h.keyslots, vec![0, 1, 2]);
+        assert_eq!(
+            h.tokens,
+            vec![
+                (0, "avocado-hwkey".into(), vec![1]),
+                (1, "avocado-recovery".into(), vec![2])
+            ]
+        );
+        assert_eq!(free_slot(&h), 3);
+        assert_eq!(describe(&h)[2], "slot 2: avocado-recovery");
+    }
+
+    #[test]
+    fn enroll_uses_the_linked_volume_key_and_records_a_token() {
+        let f = Fake::new(DUMP);
+        let msg = enroll(&f, b"secret", "hmac-sha256-uid").unwrap();
+        assert!(msg.contains("keyslot 2"), "{msg}");
+        let calls = f.calls.borrow();
+        let add = calls.iter().find(|c| c.starts_with("luksAddKey")).unwrap();
+        assert!(
+            add.contains("--volume-key-keyring %user:cryptsetup:var"),
+            "{add}"
+        );
+        assert!(add.contains("--new-key-slot 2 --pbkdf pbkdf2"), "{add}");
+        assert!(add.ends_with("/dev/mmcblk2p9"), "{add}");
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.starts_with("token import --json-file")),
+            "{calls:?}"
+        );
+        assert!(
+            !calls.iter().any(|c| c.starts_with("luksKillSlot")),
+            "nothing to replace"
+        );
+    }
+
+    #[test]
+    fn enroll_replaces_a_previous_recovery_slot_after_adding_the_new_one() {
+        let f = Fake::new(DUMP_WITH_RECOVERY);
+        enroll(&f, b"secret", "hmac-sha256-uid").unwrap();
+        let calls = f.calls.borrow();
+        let add = calls
+            .iter()
+            .position(|c| c.starts_with("luksAddKey --volume-key-keyring"))
+            .unwrap();
+        let rm_token = calls
+            .iter()
+            .position(|c| c == "token remove --token-id 1 /dev/mmcblk2p9")
+            .unwrap();
+        let kill = calls
+            .iter()
+            .position(|c| c == "luksKillSlot --batch-mode /dev/mmcblk2p9 2")
+            .unwrap();
+        assert!(add < rm_token && rm_token < kill, "{calls:?}");
+        assert!(
+            calls.iter().any(|c| c.contains("--new-key-slot 3 ")),
+            "{calls:?}"
+        );
+    }
+
+    #[test]
+    fn failed_token_import_removes_the_new_slot() {
+        let mut f = Fake::new(DUMP);
+        f.fail_import = true;
+        let err = enroll(&f, b"secret", "k").unwrap_err();
+        assert!(err.contains("keyslot 2 removed again"), "{err}");
+        assert!(f
+            .calls
+            .borrow()
+            .iter()
+            .any(|c| c == "luksKillSlot --batch-mode /dev/mmcblk2p9 2"));
+    }
+
+    #[test]
+    fn remove_needs_a_recovery_token() {
+        assert!(remove(&Fake::new(DUMP))
+            .unwrap_err()
+            .contains("no recovery keyslot"));
+        let f = Fake::new(DUMP_WITH_RECOVERY);
+        remove(&f).unwrap();
+        assert!(f
+            .calls
+            .borrow()
+            .iter()
+            .any(|c| c == "luksKillSlot --batch-mode /dev/mmcblk2p9 2"));
+    }
+
+    #[test]
+    fn empty_passphrase_is_refused_before_touching_the_device() {
+        let f = Fake::new(DUMP);
+        assert!(enroll(&f, b"", "k").is_err());
+        assert!(f.calls.borrow().is_empty());
+    }
+}

--- a/src/commands/var_key.rs
+++ b/src/commands/var_key.rs
@@ -279,19 +279,6 @@ pub fn enroll(r: &dyn Runner, passphrase: &[u8], kind: &str) -> Result<String, S
         )
     })?;
 
-    // Replace a previous recovery slot only once the new one is in place.
-    if let Some((tid, _, slots)) = recovery_token(&h).cloned() {
-        r.cryptsetup(
-            &["token", "remove", "--token-id", &tid.to_string(), &dev],
-            None,
-        )?;
-        for s in slots {
-            r.cryptsetup(
-                &["luksKillSlot", "--batch-mode", &dev, &s.to_string()],
-                None,
-            )?;
-        }
-    }
     let token = serde_json::json!({
         "type": RECOVERY_TOKEN_TYPE,
         "keyslots": [slot.to_string()],
@@ -313,6 +300,22 @@ pub fn enroll(r: &dyn Runner, passphrase: &[u8], kind: &str) -> Result<String, S
     if let Err(e) = imported {
         let _ = r.cryptsetup(&["luksKillSlot", "--batch-mode", &dev, &slot_s], None);
         return Err(format!("{e}; keyslot {slot} removed again"));
+    }
+
+    // Retire the previous recovery slot only once the new token is on disk: a
+    // failed import above must leave the existing recovery path usable, not
+    // strip the device of every recovery slot it had.
+    if let Some((tid, _, slots)) = recovery_token(&h).cloned() {
+        r.cryptsetup(
+            &["token", "remove", "--token-id", &tid.to_string(), &dev],
+            None,
+        )?;
+        for s in slots {
+            r.cryptsetup(
+                &["luksKillSlot", "--batch-mode", &dev, &s.to_string()],
+                None,
+            )?;
+        }
     }
     Ok(format!(
         "recovery keyslot {slot} enrolled on {dev} ({kind})"
@@ -486,9 +489,44 @@ mod tests {
             .iter()
             .position(|c| c == "luksKillSlot --batch-mode /dev/mmcblk2p9 2")
             .unwrap();
-        assert!(add < rm_token && rm_token < kill, "{calls:?}");
+        let import = calls
+            .iter()
+            .position(|c| c.starts_with("token import --json-file"))
+            .unwrap();
+        // The new token must be on disk before the old recovery path is retired.
+        assert!(
+            add < import && import < rm_token && rm_token < kill,
+            "{calls:?}"
+        );
         assert!(
             calls.iter().any(|c| c.contains("--new-key-slot 3 ")),
+            "{calls:?}"
+        );
+    }
+
+    #[test]
+    fn failed_token_import_leaves_the_previous_recovery_path_intact() {
+        // Retiring the old token before importing the new one left a device with
+        // no recovery slot at all when the import failed.
+        let mut f = Fake::new(DUMP_WITH_RECOVERY);
+        f.fail_import = true;
+        enroll(&f, b"secret", "hmac-sha256-uid").unwrap_err();
+        let calls = f.calls.borrow();
+        assert!(
+            !calls.iter().any(|c| c.starts_with("token remove")),
+            "the previous recovery token was removed anyway: {calls:?}"
+        );
+        assert!(
+            !calls
+                .iter()
+                .any(|c| c == "luksKillSlot --batch-mode /dev/mmcblk2p9 2"),
+            "the previous recovery keyslot was killed anyway: {calls:?}"
+        );
+        // Only the slot this run added is rolled back.
+        assert!(
+            calls
+                .iter()
+                .any(|c| c == "luksKillSlot --batch-mode /dev/mmcblk2p9 3"),
             "{calls:?}"
         );
     }

--- a/src/commands/var_key.rs
+++ b/src/commands/var_key.rs
@@ -83,7 +83,13 @@ pub fn handle_command(matches: &ArgMatches, output: &OutputManager) {
                 remove(&SystemRunner)
             }
         }
-        _ => Err("unknown var-key subcommand".to_string()),
+        // clap has subcommand_required(true), so this is unreachable in
+        // practice; refusing loudly keeps a future subcommand from silently
+        // reporting success.
+        other => Err(format!(
+            "unknown var-key subcommand {:?}",
+            other.map(|(name, _)| name).unwrap_or("<none>")
+        )),
     };
     match result {
         Ok(msg) => output.success("var-key", &msg),

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ mod varlink_client;
 mod varlink_server;
 
 use clap::{Arg, Command};
-use commands::{ext, hitl, root_authority, runtime};
+use commands::{ext, hitl, root_authority, runtime, var_key};
 use config::Config;
 use output::OutputManager;
 use varlink::org_avocado_Extensions as vl_ext;
@@ -67,6 +67,7 @@ fn main() {
         .subcommand(commands::hitl::create_command())
         .subcommand(commands::root_authority::create_command())
         .subcommand(commands::runtime::create_command())
+        .subcommand(commands::var_key::create_command())
         .subcommand(
             Command::new("status").about("Show overall system status including extensions"),
         )
@@ -773,6 +774,9 @@ fn handle_direct(matches: &clap::ArgMatches, config: &Config, output: &OutputMan
         }
         Some(("runtime", runtime_matches)) => {
             runtime::handle_command(runtime_matches, config, output);
+        }
+        Some(("var-key", vk_matches)) => {
+            var_key::handle_command(vk_matches, output);
         }
         Some(("serve", serve_matches)) => {
             let address = serve_matches

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,6 +351,17 @@ fn main() {
             }
         }
 
+        // ── var-key ──────────────────────────────────────────────────────────
+        // Not a varlink method: it manipulates the LUKS header of /var with the
+        // volume key the initramfs linked into root's keyring, which the daemon
+        // has no business proxying. Handled directly on both paths - without an
+        // arm here the daemon path fell through to the catch-all and printed
+        // the help text while exiting 0, so `avocado var-key enroll` reported
+        // success without a keyslot ever being added.
+        Some(("var-key", vk_matches)) => {
+            var_key::handle_command(vk_matches, &output);
+        }
+
         // ── root-authority ───────────────────────────────────────────────────
         Some(("root-authority", _)) => {
             let conn = varlink_client::connect_or_exit(&socket_address, &output);

--- a/src/os_update.rs
+++ b/src/os_update.rs
@@ -1842,6 +1842,24 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
+    fn a_bundle_without_an_os_build_id_is_never_satisfied() {
+        // Both activation paths call os_bundle_satisfied unconditionally and
+        // rely on this: a bundle whose rootfs identity cannot be verified must
+        // be applied rather than assumed current.
+        let tmp = TempDir::new().unwrap();
+        let bundle = crate::manifest::OsBundleRef {
+            image_id: "cf136cbe-0000-0000-0000-000000000000".to_string(),
+            sha256: "0".repeat(64),
+            os_build_id: None,
+            initramfs_build_id: Some("initramfs-1".to_string()),
+        };
+        assert!(
+            !os_bundle_satisfied(&bundle, tmp.path()),
+            "an unverifiable bundle must not count as already running"
+        );
+    }
+
+    #[test]
     fn test_determine_inactive_slot_uboot() {
         assert_eq!(determine_inactive_slot("a", "uboot-ab").unwrap(), "b");
         assert_eq!(determine_inactive_slot("b", "uboot-ab").unwrap(), "a");

--- a/src/os_update.rs
+++ b/src/os_update.rs
@@ -358,13 +358,10 @@ pub fn set_pending_runtime_id(runtime_id: &str, base_dir: &Path) -> Result<(), O
         OsUpdateError::UpdateFailed(format!("Failed to parse pending-update marker: {e}"))
     })?;
     pending.runtime_id = Some(runtime_id.to_string());
-    let json = serde_json::to_string_pretty(&pending).map_err(|e| {
-        OsUpdateError::UpdateFailed(format!("Failed to serialize pending update: {e}"))
-    })?;
-    fs::write(&path, json).map_err(|e| {
-        OsUpdateError::UpdateFailed(format!("Failed to write pending-update marker: {e}"))
-    })?;
-    Ok(())
+    // Through the same atomic writer as everything else: this runs AFTER the
+    // boot slot has been flipped, so an in-place truncating write that fails
+    // half way would destroy the only marker the next boot can roll back from.
+    write_pending_update_at(&pending, &path)
 }
 
 /// Remove the pending-update marker at a specific path (for testing).
@@ -476,13 +473,30 @@ fn write_pending_update_at(pending: &PendingUpdate, path: &Path) -> Result<(), O
         OsUpdateError::UpdateFailed(format!("Failed to serialize pending update: {e}"))
     })?;
     let tmp = path.with_extension("json.new");
-    fs::write(&tmp, json).map_err(|e| {
-        OsUpdateError::UpdateFailed(format!("Failed to write pending-update marker: {e}"))
-    })?;
+    // fsync before the rename and fsync the directory after it: this marker is
+    // the power-loss boundary for a slot flip, so "written" has to mean on the
+    // medium, not in page cache. Without the first sync a crash can leave a
+    // renamed but empty file; without the second the rename itself can be lost.
+    {
+        let mut f = fs::File::create(&tmp).map_err(|e| {
+            OsUpdateError::UpdateFailed(format!("Failed to write pending-update marker: {e}"))
+        })?;
+        f.write_all(json.as_bytes())
+            .and_then(|_| f.sync_all())
+            .map_err(|e| {
+                let _ = fs::remove_file(&tmp);
+                OsUpdateError::UpdateFailed(format!("Failed to write pending-update marker: {e}"))
+            })?;
+    }
     fs::rename(&tmp, path).map_err(|e| {
         let _ = fs::remove_file(&tmp);
         OsUpdateError::UpdateFailed(format!("Failed to install pending-update marker: {e}"))
     })?;
+    if let Some(dir) = path.parent() {
+        if let Ok(d) = fs::File::open(dir) {
+            let _ = d.sync_all();
+        }
+    }
     Ok(())
 }
 
@@ -1923,6 +1937,29 @@ mod tests {
 
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn setting_the_runtime_id_never_writes_the_marker_in_place() {
+        // This runs after the boot slot has flipped, so a truncating rewrite
+        // that fails half way destroys the only marker the next boot can roll
+        // back from. It must go through the same atomic writer.
+        let tmp = TempDir::new().unwrap();
+        let pending: PendingUpdate = serde_json::from_str(
+            r#"{"os_build_id":"os-2","verify":null,"rollback":null,"previous_slot":"a"}"#,
+        )
+        .unwrap();
+        write_pending_update(&pending, tmp.path()).unwrap();
+        set_pending_runtime_id("runtime-7", tmp.path()).unwrap();
+
+        let marker = tmp.path().join(PENDING_UPDATE_FILENAME);
+        let back = read_pending_update_from(&marker).expect("marker still parses");
+        assert_eq!(back.runtime_id.as_deref(), Some("runtime-7"));
+        assert_eq!(back.os_build_id, "os-2", "the rest of the marker survived");
+        assert!(
+            !marker.with_extension("json.new").exists(),
+            "the temp file was left behind"
+        );
+    }
 
     #[test]
     fn a_failed_activation_clears_the_marker_it_wrote() {

--- a/src/os_update.rs
+++ b/src/os_update.rs
@@ -460,12 +460,28 @@ fn pending_update_path() -> PathBuf {
 }
 
 fn write_pending_update(pending: &PendingUpdate, base_dir: &Path) -> Result<(), OsUpdateError> {
-    let path = base_dir.join(PENDING_UPDATE_FILENAME);
+    write_pending_update_at(pending, &base_dir.join(PENDING_UPDATE_FILENAME))
+}
+
+/// Write the marker so a reader never sees a partial one.
+///
+/// Every writer goes through here, including the runtime-id update that runs
+/// after the slot has already been flipped: an `fs::write` truncates in place,
+/// so a crash or ENOSPC there would leave a flipped slot with a marker that no
+/// longer parses - the next boot would find nothing to verify against and
+/// nothing to roll back to. Write a sibling temp file, then rename it over the
+/// old one, which is atomic within the directory.
+fn write_pending_update_at(pending: &PendingUpdate, path: &Path) -> Result<(), OsUpdateError> {
     let json = serde_json::to_string_pretty(pending).map_err(|e| {
         OsUpdateError::UpdateFailed(format!("Failed to serialize pending update: {e}"))
     })?;
-    fs::write(&path, json).map_err(|e| {
+    let tmp = path.with_extension("json.new");
+    fs::write(&tmp, json).map_err(|e| {
         OsUpdateError::UpdateFailed(format!("Failed to write pending-update marker: {e}"))
+    })?;
+    fs::rename(&tmp, path).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        OsUpdateError::UpdateFailed(format!("Failed to install pending-update marker: {e}"))
     })?;
     Ok(())
 }
@@ -1585,14 +1601,27 @@ pub fn apply_os_update_streaming<R: Read>(
         bundle.platform, bundle.architecture, bundle.os_build_id
     );
 
-    // 2. Check if OS is already at the target version
+    // 2. Check if OS is already at the target version. Same rule as the staged
+    // path and as os_bundle_satisfied: a matching rootfs is only half of it, or
+    // an initramfs-only bundle streams in and is thrown away here.
     if let Some(ref verify) = bundle.verify {
-        if let Ok(true) = verify_os_release(verify) {
+        let rootfs_matches = verify_os_release(verify).unwrap_or(false);
+        if write_can_be_skipped(
+            rootfs_matches,
+            bundle.initramfs_build_id.as_deref(),
+            active_manifest(base_dir).as_ref(),
+        ) {
             println!(
                 "  OS already up to date ({}={}), skipping write",
                 verify.field, verify.expected
             );
             return Ok(false);
+        }
+        if rootfs_matches {
+            println!(
+                "  Rootfs already at {}={}, but the initramfs differs — writing the bundle",
+                verify.field, verify.expected
+            );
         }
     }
 
@@ -1722,11 +1751,10 @@ pub fn apply_os_update_streaming<R: Read>(
     // 7. Patch BLS entries if needed (sdboot-ab: fix rootfs PARTLABEL in boot partition)
     maybe_patch_bls_entries(update, &inactive_slot)?;
 
-    // 8. Activate the new slot
-    println!("    Activating slot: {inactive_slot}");
-    execute_slot_actions(&update.activate, &inactive_slot, bundle.layout.as_ref())?;
-
-    // 9. Write pending-update marker
+    // 8. Write the pending-update marker BEFORE flipping, for the same reason as
+    // the staged path: it is the only breadcrumb the next boot has to verify
+    // this OS and roll a bad one back, so a crash between flip and marker would
+    // boot an unverified OS with no way back.
     let pending = PendingUpdate {
         os_build_id: bundle.os_build_id.clone(),
         initramfs_build_id: bundle.initramfs_build_id.clone(),
@@ -1738,6 +1766,16 @@ pub fn apply_os_update_streaming<R: Read>(
         runtime_id: None,
     };
     write_pending_update(&pending, base_dir)?;
+
+    // 9. Activate the new slot
+    println!("    Activating slot: {inactive_slot}");
+    if let Err(e) = execute_slot_actions(&update.activate, &inactive_slot, bundle.layout.as_ref()) {
+        // The flip failed, so the marker describes an update that is not
+        // happening: clear it rather than have the next boot verify the running
+        // OS against the new one's id and roll back a slot nothing changed.
+        let _ = clear_pending_update_at(&base_dir.join(PENDING_UPDATE_FILENAME));
+        return Err(e);
+    }
 
     println!(
         "  OS update streamed to partitions (build_id: {}). Reboot required.",

--- a/src/os_update.rs
+++ b/src/os_update.rs
@@ -1818,6 +1818,26 @@ pub fn os_bundle_satisfied(os_bundle: &crate::manifest::OsBundleRef, base_dir: &
     rootfs_matches && !initramfs_differs_from_active(os_bundle, active_manifest(base_dir).as_ref())
 }
 
+/// Where the initrd publishes the build id of the initramfs that is actually
+/// running (`avocado-initramfs-id` in meta-avocado). `/run` is created by the
+/// initrd and carried across switch-root, so this describes THIS boot: unlike a
+/// persisted stamp it cannot survive into a boot it does not describe, which
+/// matters after an A/B rollback.
+const RUNNING_INITRAMFS_ID_PATH: &str = "/run/avocado/initramfs-build-id";
+
+/// The running initramfs's build id, or `None` on an initramfs from before the
+/// publisher existed.
+fn running_initramfs_build_id() -> Option<String> {
+    read_initramfs_id_file(Path::new(RUNNING_INITRAMFS_ID_PATH))
+}
+
+fn read_initramfs_id_file(path: &Path) -> Option<String> {
+    let id = fs::read_to_string(path).ok()?.trim().to_string();
+    // An empty file is "the initrd had nothing to publish", not an id that
+    // happens to be empty - it must not compare equal to anything.
+    (!id.is_empty()).then_some(id)
+}
+
 /// Whether writing a bundle can be skipped because the running OS already is it.
 ///
 /// The rootfs matching is only half the question. An initramfs-only change ships
@@ -1835,13 +1855,32 @@ fn write_can_be_skipped(
 
 /// [`initramfs_differs_from_active`] for a target known only by its initramfs
 /// id - an on-disk bundle carries one but is not a manifest `OsBundleRef`.
-pub fn initramfs_id_differs_from_active(
+fn initramfs_id_differs_from_active(
     target_id: Option<&str>,
     active: Option<&crate::manifest::RuntimeManifest>,
+) -> bool {
+    initramfs_id_differs_from_running(target_id, active, running_initramfs_build_id().as_deref())
+}
+
+/// [`initramfs_id_differs_from_active`] with the running id passed in.
+///
+/// `running` is what the initrd published for this boot and is authoritative
+/// when present: it describes the initramfs in memory, where the active manifest
+/// only records what some earlier update intended to install. Without it the
+/// comparison falls back to the manifest, where an unknown id still counts as
+/// "no difference" - a device whose initramfs predates the publisher must not be
+/// pushed into a reboot on a guess.
+fn initramfs_id_differs_from_running(
+    target_id: Option<&str>,
+    active: Option<&crate::manifest::RuntimeManifest>,
+    running: Option<&str>,
 ) -> bool {
     let Some(target_id) = target_id else {
         return false;
     };
+    if let Some(running_id) = running {
+        return running_id != target_id;
+    }
     match active
         .and_then(|m| m.os_bundle.as_ref())
         .and_then(|b| b.initramfs_build_id.as_deref())
@@ -1996,6 +2035,69 @@ mod tests {
             initramfs_build_id: id.map(str::to_string),
         });
         m
+    }
+
+    #[test]
+    fn the_running_initramfs_id_beats_the_manifests() {
+        // The manifest records what an update intended to install; /run records
+        // what booted. When they disagree the running one is the truth.
+        let claims_match = active_with_initramfs(Some("initrd-b"));
+        assert!(initramfs_id_differs_from_running(
+            Some("initrd-b"),
+            Some(&claims_match),
+            Some("initrd-a")
+        ));
+        let unknown = active_with_initramfs(None);
+        assert!(initramfs_id_differs_from_running(
+            Some("initrd-b"),
+            Some(&unknown),
+            Some("initrd-a")
+        ));
+        assert!(!initramfs_id_differs_from_running(
+            Some("initrd-b"),
+            Some(&unknown),
+            Some("initrd-b")
+        ));
+    }
+
+    #[test]
+    fn without_a_published_id_the_manifest_comparison_is_unchanged() {
+        // An initramfs from before the publisher behaves exactly as it did, so
+        // no fielded device takes a reboot it would not have taken before.
+        let active = active_with_initramfs(Some("initrd-a"));
+        assert!(initramfs_id_differs_from_running(
+            Some("initrd-b"),
+            Some(&active),
+            None
+        ));
+        assert!(!initramfs_id_differs_from_running(
+            Some("initrd-a"),
+            Some(&active),
+            None
+        ));
+        assert!(!initramfs_id_differs_from_running(
+            Some("initrd-b"),
+            Some(&active_with_initramfs(None)),
+            None
+        ));
+        assert!(!initramfs_id_differs_from_running(
+            None,
+            Some(&active),
+            Some("initrd-z")
+        ));
+    }
+
+    #[test]
+    fn an_empty_published_id_is_not_an_id() {
+        let tmp = TempDir::new().unwrap();
+        let p = tmp.path().join("initramfs-build-id");
+        assert_eq!(read_initramfs_id_file(&p), None, "missing file");
+        fs::write(&p, "").unwrap();
+        assert_eq!(read_initramfs_id_file(&p), None, "empty file");
+        fs::write(&p, "  \n").unwrap();
+        assert_eq!(read_initramfs_id_file(&p), None, "whitespace only");
+        fs::write(&p, "initrd-a\n").unwrap();
+        assert_eq!(read_initramfs_id_file(&p), Some("initrd-a".to_string()));
     }
 
     #[test]

--- a/src/os_update.rs
+++ b/src/os_update.rs
@@ -206,13 +206,24 @@ pub fn apply_os_update(
 
     // Check if OS is already at the target version — skip if BUILD_ID matches
     if let Some(ref verify) = bundle.verify {
-        if let Ok(true) = verify_os_release(verify) {
+        let rootfs_matches = verify_os_release(verify).unwrap_or(false);
+        if write_can_be_skipped(
+            rootfs_matches,
+            bundle.initramfs_build_id.as_deref(),
+            active_manifest(base_dir).as_ref(),
+        ) {
             println!(
                 "  OS already up to date ({}={}), skipping write",
                 verify.field, verify.expected
             );
             let _ = fs::remove_dir_all(&staging_dir);
             return Ok(false);
+        }
+        if rootfs_matches {
+            println!(
+                "  Rootfs already at {}={}, but the initramfs differs — writing the bundle",
+                verify.field, verify.expected
+            );
         }
     }
 
@@ -1755,12 +1766,28 @@ pub fn os_bundle_satisfied(os_bundle: &crate::manifest::OsBundleRef, base_dir: &
     rootfs_matches && !initramfs_differs_from_active(os_bundle, active_manifest(base_dir).as_ref())
 }
 
-/// See [`os_bundle_satisfied`]: the initramfs half of the comparison.
-pub fn initramfs_differs_from_active(
-    target: &crate::manifest::OsBundleRef,
+/// Whether writing a bundle can be skipped because the running OS already is it.
+///
+/// The rootfs matching is only half the question. An initramfs-only change ships
+/// the same rootfs and a different initramfs, so a rootfs-only skip here writes
+/// nothing while every caller upstream has already decided the bundle must be
+/// applied - the runtime then goes active over an initramfs that was never
+/// written. Same rule as [`os_bundle_satisfied`], which is what the callers use.
+fn write_can_be_skipped(
+    rootfs_matches: bool,
+    target_initramfs_id: Option<&str>,
     active: Option<&crate::manifest::RuntimeManifest>,
 ) -> bool {
-    let Some(target_id) = target.initramfs_build_id.as_deref() else {
+    rootfs_matches && !initramfs_id_differs_from_active(target_initramfs_id, active)
+}
+
+/// [`initramfs_differs_from_active`] for a target known only by its initramfs
+/// id - an on-disk bundle carries one but is not a manifest `OsBundleRef`.
+pub fn initramfs_id_differs_from_active(
+    target_id: Option<&str>,
+    active: Option<&crate::manifest::RuntimeManifest>,
+) -> bool {
+    let Some(target_id) = target_id else {
         return false;
     };
     match active
@@ -1770,6 +1797,14 @@ pub fn initramfs_differs_from_active(
         Some(id) => id != target_id,
         None => false,
     }
+}
+
+/// See [`os_bundle_satisfied`]: the initramfs half of the comparison.
+pub fn initramfs_differs_from_active(
+    target: &crate::manifest::OsBundleRef,
+    active: Option<&crate::manifest::RuntimeManifest>,
+) -> bool {
+    initramfs_id_differs_from_active(target.initramfs_build_id.as_deref(), active)
 }
 
 /// The currently active runtime's manifest, if any.
@@ -1872,6 +1907,50 @@ mod tests {
             !marker.exists(),
             "a failed slot flip would leave the next boot verifying against an update that never happened"
         );
+    }
+
+    fn active_with_initramfs(id: Option<&str>) -> crate::manifest::RuntimeManifest {
+        let mut m: crate::manifest::RuntimeManifest = serde_json::from_str(
+            r#"{"manifest_version":1,"id":"active","runtime":{"name":"dev","version":"1"},"built_at":"2026-01-01T00:00:00Z","extensions":[]}"#,
+        )
+        .expect("minimal manifest");
+        m.os_bundle = Some(crate::manifest::OsBundleRef {
+            image_id: "img".into(),
+            sha256: "00".into(),
+            os_build_id: Some("os-1".into()),
+            initramfs_build_id: id.map(str::to_string),
+        });
+        m
+    }
+
+    #[test]
+    fn a_matching_rootfs_does_not_skip_an_initramfs_only_change() {
+        // The bug this pins: three callers correctly decide the bundle must be
+        // applied, apply_os_update sees the rootfs id match and writes nothing,
+        // and the runtime goes active over an initramfs that never landed.
+        let active = active_with_initramfs(Some("initrd-a"));
+        assert!(
+            !write_can_be_skipped(true, Some("initrd-b"), Some(&active)),
+            "rootfs matches but the initramfs differs: the bundle must be written"
+        );
+        assert!(
+            write_can_be_skipped(true, Some("initrd-a"), Some(&active)),
+            "same rootfs and same initramfs is genuinely nothing to do"
+        );
+        // A rootfs that does not match is written regardless of the initramfs.
+        assert!(!write_can_be_skipped(
+            false,
+            Some("initrd-a"),
+            Some(&active)
+        ));
+        // Unknown on either side keeps the old behaviour: never write on a guess.
+        assert!(write_can_be_skipped(true, None, Some(&active)));
+        assert!(write_can_be_skipped(
+            true,
+            Some("initrd-b"),
+            Some(&active_with_initramfs(None))
+        ));
+        assert!(write_can_be_skipped(true, Some("initrd-b"), None));
     }
 
     #[test]

--- a/src/os_update.rs
+++ b/src/os_update.rs
@@ -282,11 +282,10 @@ pub fn apply_os_update(
     // Patch BLS entries if needed (sdboot-ab: fix rootfs PARTLABEL in boot partition)
     maybe_patch_bls_entries(update, &inactive_slot)?;
 
-    // Activate the new slot
-    println!("    Activating slot: {inactive_slot}");
-    execute_slot_actions(&update.activate, &inactive_slot, bundle.layout.as_ref())?;
-
-    // Write pending-update marker
+    // The marker goes down BEFORE the slot flip. It is the only breadcrumb the
+    // next boot has to verify the new OS and roll back a bad one, so flipping
+    // first leaves a window where a crash - or a failed marker write - boots an
+    // unverified OS with nothing to roll back from.
     let pending = PendingUpdate {
         os_build_id: bundle.os_build_id.clone(),
         initramfs_build_id: bundle.initramfs_build_id.clone(),
@@ -298,6 +297,17 @@ pub fn apply_os_update(
         runtime_id: None,
     };
     write_pending_update(&pending, base_dir)?;
+
+    // Activate the new slot
+    println!("    Activating slot: {inactive_slot}");
+    if let Err(e) = execute_slot_actions(&update.activate, &inactive_slot, bundle.layout.as_ref()) {
+        // The flip failed, so the marker now describes an update that is not
+        // happening. Leaving it would have the next boot verify the running OS
+        // against the new one's id, call that a failure, and roll back a slot
+        // that was never changed.
+        let _ = clear_pending_update_at(&base_dir.join(PENDING_UPDATE_FILENAME));
+        return Err(e);
+    }
 
     // Clean up staging
     let _ = fs::remove_dir_all(&staging_dir);
@@ -1840,6 +1850,29 @@ mod tests {
 
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn a_failed_activation_clears_the_marker_it_wrote() {
+        // apply_os_update writes the marker into base_dir before flipping the
+        // slot and clears that same path if the flip fails. The clear must target
+        // the file the write produced, not the AVOCADO_BASE_DIR-derived default.
+        let tmp = TempDir::new().unwrap();
+        let pending: PendingUpdate = serde_json::from_str(
+            r#"{"os_build_id":"os-2","verify":null,"rollback":null,"previous_slot":"a"}"#,
+        )
+        .unwrap();
+        write_pending_update(&pending, tmp.path()).unwrap();
+        let marker = tmp.path().join(PENDING_UPDATE_FILENAME);
+        assert!(
+            marker.exists(),
+            "marker was not written where apply writes it"
+        );
+        clear_pending_update_at(&marker).unwrap();
+        assert!(
+            !marker.exists(),
+            "a failed slot flip would leave the next boot verifying against an update that never happened"
+        );
+    }
 
     #[test]
     fn a_bundle_without_an_os_build_id_is_never_satisfied() {

--- a/src/os_update.rs
+++ b/src/os_update.rs
@@ -1726,6 +1726,50 @@ pub fn apply_os_update_streaming<R: Read>(
     Ok(true)
 }
 
+/// Whether the running system already satisfies a manifest's OS bundle, so it
+/// need not be downloaded or applied. The bundle carries the rootfs *and* the
+/// boot FIT (kernel + initramfs); the rootfs is checked against the running
+/// os-release, the initramfs against the currently active runtime's record,
+/// because the running system keeps no trace of its initramfs id. Unknown ids
+/// count as "not satisfied" for the rootfs (an OS rollback must be repaired)
+/// and as "no difference" for the initramfs (never reboot on a guess).
+pub fn os_bundle_satisfied(os_bundle: &crate::manifest::OsBundleRef, base_dir: &Path) -> bool {
+    let rootfs_matches = os_bundle.os_build_id.as_ref().is_some_and(|expected| {
+        verify_os_release(&VerifyConfig {
+            verify_type: "os-release".to_string(),
+            field: "AVOCADO_OS_BUILD_ID".to_string(),
+            expected: expected.clone(),
+        })
+        .unwrap_or(false)
+    });
+    rootfs_matches && !initramfs_differs_from_active(os_bundle, active_manifest(base_dir).as_ref())
+}
+
+/// See [`os_bundle_satisfied`]: the initramfs half of the comparison.
+pub fn initramfs_differs_from_active(
+    target: &crate::manifest::OsBundleRef,
+    active: Option<&crate::manifest::RuntimeManifest>,
+) -> bool {
+    let Some(target_id) = target.initramfs_build_id.as_deref() else {
+        return false;
+    };
+    match active
+        .and_then(|m| m.os_bundle.as_ref())
+        .and_then(|b| b.initramfs_build_id.as_deref())
+    {
+        Some(id) => id != target_id,
+        None => false,
+    }
+}
+
+/// The currently active runtime's manifest, if any.
+pub fn active_manifest(base_dir: &Path) -> Option<crate::manifest::RuntimeManifest> {
+    crate::manifest::RuntimeManifest::list_all(base_dir)
+        .into_iter()
+        .find(|(_, active)| *active)
+        .map(|(m, _)| m)
+}
+
 #[cfg(test)]
 mod tests {
     fn layout_with(name: &str, offset: f64) -> BundleLayout {

--- a/src/service/runtime.rs
+++ b/src/service/runtime.rs
@@ -348,7 +348,40 @@ pub fn inspect_runtime(
     Ok(manifest_to_entry(matched, is_active))
 }
 
-/// Check if activating a runtime requires an OS change (different os_build_id).
+/// The OS bundle carries the rootfs *and* the boot FIT (kernel + initramfs),
+/// but only the rootfs leaves a trace the running system can be checked
+/// against (AVOCADO_OS_BUILD_ID in os-release). An initramfs-only change - an
+/// encryption opt-in, a var.hardware requirement - has the same rootfs id, so
+/// compare its initramfs id against the runtime that is active now: if that
+/// differs, the bundle has to be applied even though the rootfs matches.
+pub fn initramfs_differs_from_active(
+    target: &crate::manifest::OsBundleRef,
+    active: Option<&RuntimeManifest>,
+) -> bool {
+    let Some(target_id) = target.initramfs_build_id.as_deref() else {
+        return false;
+    };
+    let active_id = active
+        .and_then(|m| m.os_bundle.as_ref())
+        .and_then(|b| b.initramfs_build_id.as_deref());
+    match active_id {
+        Some(id) => id != target_id,
+        // No record of what the running initramfs is: nothing to compare, and
+        // guessing "changed" would reboot every activation.
+        None => false,
+    }
+}
+
+/// The currently active runtime's manifest, if any.
+pub fn active_manifest(base_dir: &Path) -> Option<RuntimeManifest> {
+    RuntimeManifest::list_all(base_dir)
+        .into_iter()
+        .find(|(_, active)| *active)
+        .map(|(m, _)| m)
+}
+
+/// Check if activating a runtime requires an OS change (different os_build_id,
+/// or a different initramfs than the active runtime's).
 /// If so, applies the OS update from the on-disk image and sets up the pending
 /// runtime marker for verification on next boot.
 /// Returns true if a reboot is required (caller should reboot, not refresh).
@@ -373,7 +406,9 @@ fn runtime_requires_os_change(
     })
     .unwrap_or(false);
 
-    if already_matches {
+    let initramfs_changed =
+        initramfs_differs_from_active(os_bundle, active_manifest(base_dir).as_ref());
+    if already_matches && !initramfs_changed {
         return Ok(false);
     }
 
@@ -388,10 +423,17 @@ fn runtime_requires_os_change(
         });
     }
 
-    println!(
-        "  OS change required: current rootfs does not match target AVOCADO_OS_BUILD_ID={}",
-        expected_id
-    );
+    if already_matches {
+        println!(
+            "  OS change required: the initramfs differs from the active runtime's (target initramfs_build_id={})",
+            os_bundle.initramfs_build_id.as_deref().unwrap_or("-")
+        );
+    } else {
+        println!(
+            "  OS change required: current rootfs does not match target AVOCADO_OS_BUILD_ID={}",
+            expected_id
+        );
+    }
     println!("  Applying OS update from {}...", aos_path.display());
 
     crate::os_update::apply_os_update(&aos_path, base_dir, false).map_err(|e| {
@@ -539,5 +581,59 @@ fn resolve_runtime_with_active<'a>(
                 candidates,
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod initramfs_change_tests {
+    use super::*;
+    use crate::manifest::OsBundleRef;
+
+    fn bundle(initramfs: Option<&str>) -> OsBundleRef {
+        OsBundleRef {
+            image_id: "img".into(),
+            sha256: "00".into(),
+            os_build_id: Some("os-1".into()),
+            initramfs_build_id: initramfs.map(str::to_string),
+        }
+    }
+
+    fn active_with(initramfs: Option<&str>) -> RuntimeManifest {
+        let mut m: RuntimeManifest = serde_json::from_str(
+            r#"{"manifest_version":1,"id":"active","runtime":{"name":"dev","version":"1"},"built_at":"2026-01-01T00:00:00Z","extensions":[]}"#,
+        )
+        .expect("minimal manifest");
+        m.os_bundle = Some(bundle(initramfs));
+        m
+    }
+
+    #[test]
+    fn same_rootfs_different_initramfs_is_an_os_change() {
+        let active = active_with(Some("initrd-a"));
+        assert!(initramfs_differs_from_active(
+            &bundle(Some("initrd-b")),
+            Some(&active)
+        ));
+        assert!(!initramfs_differs_from_active(
+            &bundle(Some("initrd-a")),
+            Some(&active)
+        ));
+    }
+
+    #[test]
+    fn unknown_sides_never_force_a_reboot() {
+        let active = active_with(None);
+        assert!(!initramfs_differs_from_active(
+            &bundle(Some("initrd-b")),
+            Some(&active)
+        ));
+        assert!(!initramfs_differs_from_active(
+            &bundle(None),
+            Some(&active_with(Some("x")))
+        ));
+        assert!(!initramfs_differs_from_active(
+            &bundle(Some("initrd-b")),
+            None
+        ));
     }
 }

--- a/src/service/runtime.rs
+++ b/src/service/runtime.rs
@@ -348,38 +348,6 @@ pub fn inspect_runtime(
     Ok(manifest_to_entry(matched, is_active))
 }
 
-/// The OS bundle carries the rootfs *and* the boot FIT (kernel + initramfs),
-/// but only the rootfs leaves a trace the running system can be checked
-/// against (AVOCADO_OS_BUILD_ID in os-release). An initramfs-only change - an
-/// encryption opt-in, a var.hardware requirement - has the same rootfs id, so
-/// compare its initramfs id against the runtime that is active now: if that
-/// differs, the bundle has to be applied even though the rootfs matches.
-pub fn initramfs_differs_from_active(
-    target: &crate::manifest::OsBundleRef,
-    active: Option<&RuntimeManifest>,
-) -> bool {
-    let Some(target_id) = target.initramfs_build_id.as_deref() else {
-        return false;
-    };
-    let active_id = active
-        .and_then(|m| m.os_bundle.as_ref())
-        .and_then(|b| b.initramfs_build_id.as_deref());
-    match active_id {
-        Some(id) => id != target_id,
-        // No record of what the running initramfs is: nothing to compare, and
-        // guessing "changed" would reboot every activation.
-        None => false,
-    }
-}
-
-/// The currently active runtime's manifest, if any.
-pub fn active_manifest(base_dir: &Path) -> Option<RuntimeManifest> {
-    RuntimeManifest::list_all(base_dir)
-        .into_iter()
-        .find(|(_, active)| *active)
-        .map(|(m, _)| m)
-}
-
 /// Check if activating a runtime requires an OS change (different os_build_id,
 /// or a different initramfs than the active runtime's).
 /// If so, applies the OS update from the on-disk image and sets up the pending
@@ -406,9 +374,7 @@ fn runtime_requires_os_change(
     })
     .unwrap_or(false);
 
-    let initramfs_changed =
-        initramfs_differs_from_active(os_bundle, active_manifest(base_dir).as_ref());
-    if already_matches && !initramfs_changed {
+    if crate::os_update::os_bundle_satisfied(os_bundle, base_dir) {
         return Ok(false);
     }
 
@@ -588,6 +554,7 @@ fn resolve_runtime_with_active<'a>(
 mod initramfs_change_tests {
     use super::*;
     use crate::manifest::OsBundleRef;
+    use crate::os_update::initramfs_differs_from_active;
 
     fn bundle(initramfs: Option<&str>) -> OsBundleRef {
         OsBundleRef {

--- a/src/service/runtime.rs
+++ b/src/service/runtime.rs
@@ -361,18 +361,21 @@ fn runtime_requires_os_change(
         Some(b) => b,
         None => return Ok(false),
     };
-    let expected_id = match &os_bundle.os_build_id {
-        Some(id) => id,
-        None => return Ok(false),
-    };
+    // No early return when the bundle carries no os_build_id: os_bundle_satisfied
+    // is the source of truth and treats an unverifiable bundle as not satisfied.
+    // Returning "no OS change" here is how an initramfs-only runtime went active
+    // with its bundle never applied.
+    let expected_id = os_bundle.os_build_id.as_ref();
 
     // Check if the running rootfs already matches
-    let already_matches = crate::os_update::verify_os_release(&crate::os_update::VerifyConfig {
-        verify_type: "os-release".to_string(),
-        field: "AVOCADO_OS_BUILD_ID".to_string(),
-        expected: expected_id.clone(),
-    })
-    .unwrap_or(false);
+    let already_matches = expected_id.is_some_and(|expected| {
+        crate::os_update::verify_os_release(&crate::os_update::VerifyConfig {
+            verify_type: "os-release".to_string(),
+            field: "AVOCADO_OS_BUILD_ID".to_string(),
+            expected: expected.clone(),
+        })
+        .unwrap_or(false)
+    });
 
     if crate::os_update::os_bundle_satisfied(os_bundle, base_dir) {
         return Ok(false);
@@ -394,10 +397,14 @@ fn runtime_requires_os_change(
             "  OS change required: the initramfs differs from the active runtime's (target initramfs_build_id={})",
             os_bundle.initramfs_build_id.as_deref().unwrap_or("-")
         );
-    } else {
+    } else if let Some(expected_id) = expected_id {
         println!(
             "  OS change required: current rootfs does not match target AVOCADO_OS_BUILD_ID={}",
             expected_id
+        );
+    } else {
+        println!(
+            "  OS change required: the bundle carries no AVOCADO_OS_BUILD_ID to verify the running rootfs against"
         );
     }
     println!("  Applying OS update from {}...", aos_path.display());

--- a/src/update.rs
+++ b/src/update.rs
@@ -300,22 +300,14 @@ pub fn perform_update(
                         existing_images.insert(bundle_filename.clone());
                     }
 
-                    if let Some(ref expected_id) = os_bundle.os_build_id {
-                        let matches =
-                            crate::os_update::verify_os_release(&crate::os_update::VerifyConfig {
-                                verify_type: "os-release".to_string(),
-                                field: "AVOCADO_OS_BUILD_ID".to_string(),
-                                expected: expected_id.clone(),
-                            })
-                            .unwrap_or(false);
-                        if matches {
-                            // OS is already at target version — skip downloading the bundle
-                            println!(
-                                "    OS already at target version (AVOCADO_OS_BUILD_ID={expected_id}), skipping OS bundle download"
-                            );
-                            existing_images.insert(bundle_filename);
-                            os_bundle_skipped = true;
-                        }
+                    // Rootfs and initramfs both already running: nothing to fetch.
+                    if crate::os_update::os_bundle_satisfied(os_bundle, base_dir) {
+                        println!(
+                            "    OS already at target version (AVOCADO_OS_BUILD_ID={}), skipping OS bundle download",
+                            os_bundle.os_build_id.as_deref().unwrap_or("unknown")
+                        );
+                        existing_images.insert(bundle_filename);
+                        os_bundle_skipped = true;
                     }
                 }
             }
@@ -492,7 +484,7 @@ pub(crate) fn acquire_update_lock(base_dir: &Path) -> Result<File, UpdateError> 
 /// already active and intact, and the running OS already satisfies the
 /// manifest's os_bundle (if any).
 fn is_already_current(manifest: &RuntimeManifest, base_dir: &Path) -> bool {
-    is_runtime_current(manifest, base_dir) && os_requirement_satisfied(manifest)
+    is_runtime_current(manifest, base_dir) && os_requirement_satisfied(manifest, base_dir)
 }
 
 /// The active runtime matches `manifest` and every *extension* image it lists
@@ -527,19 +519,11 @@ fn is_runtime_current(manifest: &RuntimeManifest, base_dir: &Path) -> bool {
 /// knows how to apply a bundle. That asymmetry matters after an OS rollback:
 /// the active runtime id still matches, but the OS no longer does, and a
 /// re-nudge must repair the OS rather than report nothing to do.
-fn os_requirement_satisfied(manifest: &RuntimeManifest) -> bool {
+fn os_requirement_satisfied(manifest: &RuntimeManifest, base_dir: &Path) -> bool {
     let Some(ref os_bundle) = manifest.os_bundle else {
         return true;
     };
-
-    os_bundle.os_build_id.as_ref().is_some_and(|expected| {
-        crate::os_update::verify_os_release(&crate::os_update::VerifyConfig {
-            verify_type: "os-release".to_string(),
-            field: "AVOCADO_OS_BUILD_ID".to_string(),
-            expected: expected.clone(),
-        })
-        .unwrap_or(false)
-    })
+    crate::os_update::os_bundle_satisfied(os_bundle, base_dir)
 }
 
 /// Complete the update after the runtime has been staged.
@@ -561,16 +545,7 @@ fn finish_update(
     // When an OS update is applied, the runtime stays pending (not active) — it will
     // be promoted to active on the next boot after the OS build ID is verified.
     if let Some(ref os_bundle) = new_manifest.os_bundle {
-        let skip = if let Some(ref expected_id) = os_bundle.os_build_id {
-            crate::os_update::verify_os_release(&crate::os_update::VerifyConfig {
-                verify_type: "os-release".to_string(),
-                field: "AVOCADO_OS_BUILD_ID".to_string(),
-                expected: expected_id.clone(),
-            })
-            .unwrap_or(false)
-        } else {
-            false
-        };
+        let skip = crate::os_update::os_bundle_satisfied(os_bundle, base_dir);
 
         if skip {
             println!(
@@ -1363,7 +1338,10 @@ mod tests {
     #[test]
     fn no_os_bundle_imposes_no_os_requirement() {
         let manifest = already_current_manifest("d164f0d8-f9f3-4597-8413-42a6429fe17d");
-        assert!(os_requirement_satisfied(&manifest));
+        assert!(os_requirement_satisfied(
+            &manifest,
+            std::path::Path::new("/nonexistent-avocado-base")
+        ));
     }
 
     /// An unverifiable bundle (no build id, or an os-release that does not
@@ -1380,12 +1358,18 @@ mod tests {
             os_build_id: None,
             initramfs_build_id: None,
         });
-        assert!(!os_requirement_satisfied(&manifest));
+        assert!(!os_requirement_satisfied(
+            &manifest,
+            std::path::Path::new("/nonexistent-avocado-base")
+        ));
 
         // The host running the test suite is not an Avocado OS at this build.
         manifest.os_bundle.as_mut().unwrap().os_build_id =
             Some("a-build-id-no-real-os-release-carries".to_string());
-        assert!(!os_requirement_satisfied(&manifest));
+        assert!(!os_requirement_satisfied(
+            &manifest,
+            std::path::Path::new("/nonexistent-avocado-base")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Adds `avocadoctl var-key enroll|list|remove`, the device half of the operator-held `/var` recovery key.

**Why:** the hardware-bound keyslots (CAAM, TPM2) can never be recovered off-device; an operator-held key gives a bench recovery path and lets the SoC-UID-derived slot be retired. The passphrase is never stored on the device — avocado-cli derives it per unit (`HMAC(master, SoC UID)`) and pipes it in over the device session.

**How it authorises:** none of the existing keyslot passphrases are reachable from the running system (they live in the initramfs), so `enroll` uses the *volume key* that `cryptsetup-var` links into root's user keyring at open time (`--link-vk-to-keyring @u::%user:cryptsetup:var`, companion meta-avocado change) via `luksAddKey --volume-key-keyring`. The slot is tagged with an `avocado-recovery` LUKS2 token so the initramfs and posture can see it.

**Behaviour**
- `enroll`: first free slot, PBKDF2 (input is high-entropy), token import; a previous recovery slot is replaced only after the new one exists; a failed token import removes the slot it just added.
- `remove --yes`: token + slot removal; refuses without the flag.
- `list`: keyslots and which token (hwkey/tpm2/recovery) unlocks each.
- Backing device from `cryptsetup status var`, so partition labels don't matter.

**Tests:** all system access goes through a `Runner` trait; six unit tests drive the logic against recorded `luksDump` output (argv of every cryptsetup call, replace ordering, rollback on failed import, refusals).

Companion: meta-avocado `jschneck/var-recovery-key` (links the volume key on open, retires the derived slot once a recovery token exists, publishes `avocado_var_recovery`); avocado-cli `jschneck/var-recovery-key` (`var.recovery`, `avocado var-key enroll|derive`).

**Also in this PR — `runtime`: an initramfs-only change is an OS change.** Activation compared only the rootfs id against the running os-release, so a runtime whose only difference is the initramfs (encrypted-var opt-in, `var.hardware`, a new cryptsetup-var) was activated without applying the bundle and the device kept booting the old initrd (seen on imx8mp-evk). Now the target's `initramfs_build_id` is compared with the active runtime's as well; unknown ids never force a reboot. Unit tests for the decision.
